### PR TITLE
Added docs for dateTimeFormat function

### DIFF
--- a/data/en/datetimeformat.json
+++ b/data/en/datetimeformat.json
@@ -1,0 +1,18 @@
+{
+	"name":"dateTimeFormat",
+	"type":"function",
+	"syntax":"dateTimeFormat(dateTime [, mask])",
+	"returns":"String",
+	"related":["dateFormat","timeFormat"],
+	"description":" Formats a datetime value using U.S. date and time formats. For\n international date support, use LSDateTimeFormat.\n [mask - quicky]\nd: Day of the month as digits; no leading zero for single-digit days.\ndd: Day of the month as digits; leading zero for single-digit days.\nddd: Day of the week as a three-letter abbreviation.\ndddd: Day of the week as its full name.\nm: Month as digits; no leading zero for single-digit months.\nmm: Month as digits; leading zero for single-digit months.\nmmm: Month as a three-letter abbreviation.\nmmmm: Month as its full name.\nyy: Year as last two digits; leading zero for years less than 10.\nyyyy: Year represented by four digits.\ngg: Period/era string.\nh: hours; no leading zero for single-digit hours (12-hour clock)\nhh: hours; leading zero for single-digit hours (12-hour clock)\nH: hours; no leading zero for single-digit hours (24-hour clock)\nHH: hours; leading zero for single-digit hours (24-hour clock)\nn: minutes; no leading zero for single-digit minutes\nnn: minutes; a leading zero for single-digit minutes\ns: seconds; no leading zero for single-digit seconds\nss: seconds; leading zero for single-digit seconds\nl or L: milliseconds, with no leading zeros\nt: one-character time marker string, such as A or P\ntt: multiple-character time marker string, such as AM or PM",
+	"params": [ 
+		{"name":"dateTime","description":"","required":true,"default":"","type":"DateTime","values":["now()"]},
+		{"name":"mask","description":"","required":false,"default":"","type":"String","values":["short","medium","long","full","see tokens above"]}
+	],
+	"engines": {
+		"coldfusion": {"minimum_version":"10", "notes":"", "docs":"https://learn.adobe.com/wiki/display/coldfusionen/datetimeformat"},
+		"railo": {"minimum_version":"4.0.1", "notes":"No documentation exists for this function on Railo, however LSDateTimeFormat is documented. Follows Java date time mask. For details, see the section Date and Time Patterns at the following URL: http://docs.oracle.com/javase/1.4.2/docs/api/java/text/SimpleDateFormat.html ", "docs":"http://railodocs.org/index.cfm/function/lsdateformat"},
+		"openbd": {"minimum_version":"", "notes":"Some of the mask tokens differ from Adobe ColdFusion", "docs":"http://openbd.org/manual/?/function/datetimeformat"}
+	},
+	"links": []
+}


### PR DESCRIPTION
Let me know if I misused any of the elements. I couldn't find any examples of "related" items so I guessed at the format it was expecting. I also pointed the railo docs at LSDateTimeFormat because they don't have docs for DateTimeFormat. No idea whether or not they have a DateTimeFormat function.
