### PR TITLE
Remove invalid characters and fix spacing of `SELECT`.

### DIFF
--- a/data/en/cfabort.json
+++ b/data/en/cfabort.json
@@ -5,9 +5,9 @@
 	"returns":"",
 	"related":[],
 	"description":" Stops the processing of a CFML page at the tag location.\n CFML returns everything that was processed before the\n tag. The tag is often used with conditional logic to stop\n processing a page when a condition occurs.",
-	"params": [ 
+	"params": [
 		{"name":"showerror","description":"Error to display, in a standard CFML error page,\n when tag executes","required":false,"default":"","type":"String","values":[]},
-		{"name":"attributecollection","description":"You can specify this tag's attributes in an attributeCollection whose value is a \n structure. Specify the structure name in the attributeCollection and use the tag‚Äôs \n attribute names as structure keys.","required":false,"default":"","type":"String","values":[]}
+		{"name":"attributecollection","description":"You can specify this tag's attributes in an attributeCollection whose value is a \n structure. Specify the structure name in the attributeCollection and use the tag‚ \n attribute names as structure keys.","required":false,"default":"","type":"String","values":[]}
 
 	],
 	"engines": {
@@ -16,7 +16,7 @@
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/tag/cfabort"}
 	},
 	"links": [
-		
+
 	]
-	
+
 }

--- a/data/en/cfajaximport.json
+++ b/data/en/cfajaximport.json
@@ -5,11 +5,11 @@
 	"returns":"",
 	"related":[],
 	"description":" Controls the JavaScript files that are imported for use on pages that use ColdFusion AJAX \n tags and features.",
-	"params": [ 
+	"params": [
 		{"name":"scriptsrc","description":"Specifies the URL, relative to the web root, of the \n directory that contains the JavaScript files used \n used by ColdFusion. When you use this attribute, \n the specified directory must have the same \n structure as the \/CFIDE\/scripts directory.","required":false,"default":"","type":"String","values":[]},
 		{"name":"csssrc","description":"Specifies the URL, relative to the web root, of the \n directory that contains the CSS files used by \n ColdFusion AJAX features, with the exception of \n the rich text editor. This directory must have the \n same directory structure, and contain the same \n CSS files, and image files required by the CSS \n files, as the \n web_root\/CFIDE\/scripts\/ajax\/resources \n directory. \n This attribute lets you create different custom \n styles for ColdFusion AJAX controls in different \n applications.","required":false,"default":"","type":"String","values":[]},
 		{"name":"tags","description":"A comma-delimited list of tags or tag-attribute \n combinations for which to import the supporting \n JavaScript files on this page.","required":false,"default":"","type":"String","values":[]},
-		{"name":"attributecollection","description":"You can specify this tag's attributes in an attributeCollection whose value is a \n structure. Specify the structure name in the attributeCollection and use the tag‚Äôs \n attribute names as structure keys.","required":false,"default":"","type":"String","values":[]}
+		{"name":"attributecollection","description":"You can specify this tag's attributes in an attributeCollection whose value is a \n structure. Specify the structure name in the attributeCollection and use the tag‚ \n attribute names as structure keys.","required":false,"default":"","type":"String","values":[]}
 
 	],
 	"engines": {
@@ -18,7 +18,7 @@
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/tag/cfajaximport"}
 	},
 	"links": [
-		
+
 	]
-	
+
 }

--- a/data/en/cfapplication.json
+++ b/data/en/cfapplication.json
@@ -5,7 +5,7 @@
 	"returns":"",
 	"related":[],
 	"description":" Defines the scope of a CFML application; enables and\n disables storage of Client variables; specifies the Client\n variable storage mechanism; enables Session variables; and\n sets Application variable timeouts.",
-	"params": [ 
+	"params": [
 		{"name":"name","description":"Name of application. Up to 64 characters","required":false,"default":"","type":"String","values":[]},
 		{"name":"loginstorage","description":"cookie: store login information in the Cookie scope.\n session: store login information in the Session scope.","required":false,"default":"cookie","type":"String","values":["cookie","session"]},
 		{"name":"clientmanagement","description":"enables client variables","required":false,"default":false,"type":"boolean","values":[true,false]},
@@ -18,7 +18,7 @@
 		{"name":"scriptprotect","description":"Specifies whether to protect variables from cross-site scripting attacks.\n - none: do not protect variables\n - all: protect Form, URL, CGI, and Cookie variables\n - comma-delimited list of ColdFusion scopes: protect variables in the specified scopes","required":false,"default":"","type":"String","values":["none","all","form","url","cookie","cgi","form,url","form,url,cookie","form,url,cookie,cgi"]},
 		{"name":"securejsonprefix","description":"The security prefix to put in front of the value that a ColdFusion function returns in JSON-format \n\t\t\t\tin response to a remote call if the secureJSON setting is true.","required":false,"default":"","type":"String","values":[true,false]},
 		{"name":"securejson","description":"A Boolean value that specifies whether to add a security prefix in front of any value that a ColdFusion function returns in JSON-format\n\t\t\t\t in response to a remote call.","required":false,"default":"","type":"Boolean","values":[true,false]},
-		{"name":"serverSideFormValidation","description":"Enable\/Disable ColdFusion‚Äôs server side validation on CFFORM.","required":false,"default":"","type":"Boolean","values":[true,false]}
+		{"name":"serverSideFormValidation","description":"Enable\/Disable ColdFusion‚ server side validation on CFFORM.","required":false,"default":"","type":"Boolean","values":[true,false]}
 
 	],
 	"engines": {
@@ -27,7 +27,7 @@
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/tag/cfapplication"}
 	},
 	"links": [
-		
+
 	]
-	
+
 }

--- a/data/en/cfcomponent.json
+++ b/data/en/cfcomponent.json
@@ -5,7 +5,7 @@
 	"returns":"",
 	"related":[],
 	"description":" Creates and defines a component object; encloses functionality\n that you build in CFML and enclose within cffunction tags.\n This tag contains one or more cffunction tags that define\n methods. Code within the body of this tag, other than\n cffunction tags, is executed when the component is\n instantiated.",
-	"params": [ 
+	"params": [
 		{"name":"extends","description":"Name of parent component from which to inherit methods and\n properties.","required":false,"default":"","type":"String","values":[]},
 		{"name":"initmethod","description":"Method that will be called when ColdFusion instantiates the component","required":false,"default":"","type":"String","values":[]},
 		{"name":"implements","description":"Name of the ColdFusion interface or interfaces \n that this component implements. If the \n component implements an interface, it must \n define all the functions in the interface, and the \n function definitions must conform to the \n definitions specified in the interface. For more \n information, see cfinterface. \n A component can implement any number of \n interfaces. To specify multiple interface, use a \n comma delimited list, of the format \n interface1,interface2.","required":false,"default":"","type":"String","values":[]},
@@ -40,7 +40,7 @@
 		{"name":"cacheName","description":"Use this value to specify the name of the secondary cache.","required":false,"default":"","type":"String","values":[]},
 		{"name":"saveMapping","description":"Specifies whether the generated Hibernate mapping file has to be saved to disk. If you set the value to true, the Hibernate mapping XML file is saved with the filename \"CFC name\".hbm.xml in the same directory as the CFC.","required":false,"default":false,"type":"boolean","values":[true,false]},
 		{"name":"accessors","description":"If set to false, ColdFusion ORM does not generate the implicit getters and setters.","required":false,"default":"","type":"boolean","values":[true,false]},
-		{"name":"serializable","description":"Specifies whether this component can be serialized. If you set this value to false, the component and the data in the component‚Äôs This and Variables scopes cannot be serialized, so they are not retained on session replication, and the component is in its default state.","required":false,"default":"","type":"Boolean","values":[true,false]},
+		{"name":"serializable","description":"Specifies whether this component can be serialized. If you set this value to false, the component and the data in the component‚ This and Variables scopes cannot be serialized, so they are not retained on session replication, and the component is in its default state.","required":false,"default":"","type":"Boolean","values":[true,false]},
 		{"name":"attribute","description":"If the attribute is set to ‚Äúfalse‚Äù at the component level, then the implicit getters and setters for the individual properties are ignored.","required":false,"default":true,"type":"Boolean","values":[true,false]}
 
 	],
@@ -50,7 +50,7 @@
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/tag/cfcomponent"}
 	},
 	"links": [
-		
+
 	]
-	
+
 }

--- a/data/en/cfinput.json
+++ b/data/en/cfinput.json
@@ -5,12 +5,12 @@
 	"returns":"",
 	"related":[],
 	"description":" Used within the cfform tag, to place radio buttons, check boxes,\n or text boxes on a form. Provides input validation for the\n specified control type.",
-	"params": [ 
+	"params": [
 		{"name":"name","description":"Name for form input element.","required":true,"default":"","type":"String","values":[]},
 		{"name":"autosuggest","description":"Specifies entry completion suggestions to \n display as the user types into a text input. The \n user can select a suggestion to complete the text \n entry. \n The valid value can be either of the following: \n ‚Ä¢ A string consisting of the suggestion values \n separated by the delimiter specified by the \n delimiter attribute. \n ‚Ä¢ A bind expression that gets the suggestion \n values based on the current input text. \n Valid only for cfinput type=\"text\".","required":false,"default":"","type":"String","values":[]},
 		{"name":"autoSuggestBindDelay","description":"The minimum time between autosuggest bind \n expression invocations, in seconds. Use this \n attribute to limit the number of requests that are \n sent to the server when a user types. \n Valid only for cfinput type=\"text\"","required":false,"default":"","type":"Numeric","values":[]},
 		{"name":"autoSuggestMinLength","description":"The minimum number of characters required in \n the text box before invoking a bind expression to \n return items for suggestion. \n Valid only for cfinput type=\"text\".","required":false,"default":"","type":"Numeric","values":[]},
-		{"name":"bindAttribute","description":"Specifies the HTML tag attribute whose value is \n set by the bind attribute. You can only specify \n attributes in the browser‚Äôs HTML DOM tree, not \n ColdFusion-specific attributes. \n Ignored if there is no bind attribute. \n Valid only for cfinput type=\"text\".","required":false,"default":"","type":"String","values":[]},
+		{"name":"bindAttribute","description":"Specifies the HTML tag attribute whose value is \n set by the bind attribute. You can only specify \n attributes in the browser‚ HTML DOM tree, not \n ColdFusion-specific attributes. \n Ignored if there is no bind attribute. \n Valid only for cfinput type=\"text\".","required":false,"default":"","type":"String","values":[]},
 		{"name":"bindonload","description":"A Boolean value that specifies whether to \n execute the bind attribute expression when first \n loading the form. \n Ignored if there is no bind attribute. \n Valid only for cfinput type=\"text\".","required":false,"default":false,"type":"boolean","values":[true,false]},
 		{"name":"id","description":"ID for form input element.","required":false,"default":"","type":"String","values":[]},
 		{"name":"type","description":"The input control type to create:\n - button: push button.\n - checkbox: check box.\n - file: file selector; not supported in Flash.\n - hidden: invisible control.\n - image: clickable button with an image.\n - password: password entry control; hides input values.\n - radio: radio button.\n - reset: form reset button.\n - submit: form submission button.\n - text: text entry box.\n - datefield: Flash only; date entry field with an\n expanding calendar for selecting dates.","required":false,"default":"text","type":"String","values":["button","checkbox","file","hidden","image","password","radio","reset","submit","text","datefield","autosuggest"]},
@@ -63,7 +63,7 @@
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/tag/cfinput"}
 	},
 	"links": [
-		
+
 	]
-	
+
 }

--- a/data/en/cfquery.json
+++ b/data/en/cfquery.json
@@ -5,7 +5,7 @@
 	"returns":"",
 	"related":["cfqueryparam"],
 	"description":" Passes queries or SQL statements to a data source.\n It is recommended that you use the cfqueryparam tag within\n every cfquery tag, to help secure your databases from\n unauthorized users",
-	"params": [ 
+	"params": [
 		{"name":"name","description":"Name of query. Used in page to reference query record set.\n Must begin with a letter. Can include letters, numbers,\n and underscores.","required":false,"default":"","type":"String","values":[]},
 		{"name":"datasource","description":"Name of data source from which query gets data.","required":false,"default":"","type":"String","values":[]},
 		{"name":"dbtype","description":"query. Use this value to specify the results of a query as\n input.","required":false,"default":"","type":"String","values":[]},
@@ -26,16 +26,16 @@
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/tag/cfquery"}
 	},
 	"links": [
-		
+
 	],
 	"examples": [
 		{
 			"title": "Example CFQuery with CFQueryParam",
 			"description": "Shows how to use a cfqueryparam tag within cfquery.",
-			"code": "<cfquery name=\"news\">\n   SELECT id,title,story\n    FROM news\n    WHERE id = <cfqueryparam value=\"#url.id#\" cfsqltype=\"cf_sql_integer\">\n</cfquery>",
+			"code": "<cfquery name=\"news\">\n    SELECT id,title,story\n    FROM news\n    WHERE id = <cfqueryparam value=\"#url.id#\" cfsqltype=\"cf_sql_integer\">\n</cfquery>",
 			"result": ""
 		}
-	]		
-	
-	
+	]
+
+
 }

--- a/data/en/cfselect.json
+++ b/data/en/cfselect.json
@@ -5,11 +5,11 @@
 	"returns":"",
 	"related":[],
 	"description":" Constructs a drop-down list box form control. Used within a\n cfform tag.\n\n You can populate the list from a query, or by using the HTML\n option tag.",
-	"params": [ 
+	"params": [
 		{"name":"name","description":"Name of the select form element","required":true,"default":"","type":"String","values":[]},
 		{"name":"id","description":"ID for form input element.","required":false,"default":"","type":"String","values":[]},
 		{"name":"bind","description":"A bind expression that dynamically sets an attribute \n of the control.","required":false,"default":"","type":"String","values":[]},
-		{"name":"bindAttribute","description":"Specifies the HTML tag attribute whose value is set \n by the bind attribute. You can only specify attributes \n in the browser‚Äôs HTML DOM tree, not ColdFusion- \n specific attributes. \n Ignored if there is no bind attribute.","required":false,"default":"","type":"String","values":[]},
+		{"name":"bindAttribute","description":"Specifies the HTML tag attribute whose value is set \n by the bind attribute. You can only specify attributes \n in the browser‚ HTML DOM tree, not ColdFusion- \n specific attributes. \n Ignored if there is no bind attribute.","required":false,"default":"","type":"String","values":[]},
 		{"name":"bindOnLoad","description":"A Boolean value that specifies whether to execute \n the bind attribute expression when first loading the \n form. Ignored if there is no bind attribute.","required":false,"default":false,"type":"boolean","values":[true,false]},
 		{"name":"editable","description":"Boolean value specifying whether you can edit the \n contents of the control.","required":false,"default":false,"type":"boolean","values":[true,false]},
 		{"name":"label","description":"Label to put next to the control on a Flash or XML-format form.","required":false,"default":"","type":"String","values":[]},
@@ -47,7 +47,7 @@
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/tag/cfselect"}
 	},
 	"links": [
-		
+
 	]
-	
+
 }


### PR DESCRIPTION
### What the changes do

- [x] Remove invalid `Äôs` characters.
- [x] Fix spacing of `SELECT` in `CFQUERY` doc.