### PR TITLE
Add engine-specific labels and colors

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -69,3 +69,25 @@ h2 .item-name { font-weight:bold; }
 .breadcrumb li.pull-right:before { content: " ";}
 footer { text-align: center; margin-top: 10px; font-size:smaller; }
 .navbar-brand { font-weight:bold; }
+
+.label-acf {
+    background-color: #069;
+}
+.label-acf:hover,
+.label-acf:focus {
+    background-color: #246;
+}
+.label-lucee {
+    background-color: #449caf;
+}
+.label-lucee:hover,
+.label-lucee:focus {
+    background-color: #01798a;
+}
+.label-openbd {
+    background-color: #2fa5d7;
+}
+.label-openbd:hover,
+.label-openbd:focus {
+    background-color: #1b6c8f;
+}

--- a/views/doc.cfm
+++ b/views/doc.cfm
@@ -41,17 +41,17 @@
 
 	  <cfif StructKeyExists(data, "engines") AND StructKeyExists(data.engines, "coldfusion") AND StructKeyExists(data.engines.coldfusion, "docs") AND Len(data.engines.coldfusion.docs)>
 	  		<li class="pull-right">
-	  			<a href="#data.engines.coldfusion.docs#" title="Official Adobe ColdFusion Docs" class="label label-info">CF<cfif StructKeyExists(data.engines.coldfusion, "minimum_version") AND Len(data.engines.coldfusion.minimum_version)>#XmlFormat(data.engines.coldfusion.minimum_version)#+</cfif></a>
+	  			<a href="#data.engines.coldfusion.docs#" title="Official Adobe ColdFusion Docs" class="label label-acf">CF<cfif StructKeyExists(data.engines.coldfusion, "minimum_version") AND Len(data.engines.coldfusion.minimum_version)>#XmlFormat(data.engines.coldfusion.minimum_version)#+</cfif></a>
 	  		</li>
 	  </cfif>
 	  <cfif StructKeyExists(data, "engines") AND StructKeyExists(data.engines, "lucee") AND StructKeyExists(data.engines.lucee, "docs") AND Len(data.engines.lucee.docs)>
 	  		<li class="pull-right">
-	  			<a href="#data.engines.lucee.docs#" title="Official Lucee Docs" class="label label-danger">L<cfif StructKeyExists(data.engines.lucee, "minimum_version") AND Len(data.engines.railo.minimum_version)>#XmlFormat(data.engines.lucee.minimum_version)#+</cfif></a>
+	  			<a href="#data.engines.lucee.docs#" title="Official Lucee Docs" class="label label-lucee">L<cfif StructKeyExists(data.engines.lucee, "minimum_version") AND Len(data.engines.railo.minimum_version)>#XmlFormat(data.engines.lucee.minimum_version)#+</cfif></a>
 	  		</li>
 	  </cfif>
 	  <cfif StructKeyExists(data, "engines") AND StructKeyExists(data.engines, "openbd") AND StructKeyExists(data.engines.openbd, "docs") AND Len(data.engines.openbd.docs)>
 	  		<li class="pull-right">
-	  			<a href="#data.engines.openbd.docs#" title="Official OpenBD Docs" class="label label-default">BD</a>
+	  			<a href="#data.engines.openbd.docs#" title="Official OpenBD Docs" class="label label-openbd">BD</a>
 	  		</li>
 	  </cfif>
 	</ol>


### PR DESCRIPTION
The ACF, Lucee and OpenBD labels in the engine list now use colors
pulled from their respective websites to apply more obvious visual
connections to the engines themselves.