### PR TITLE
Fixes formatting & js issues in trycf editor

### DIFF
--- a/assets/code-editor.css
+++ b/assets/code-editor.css
@@ -182,3 +182,7 @@ h2.error{font-size:1em;margin-top:2em;text-align:center;color:#c5bcb4;line-heigh
 .modal-solution {
 	width: 750px;
 }
+span.code-editor-message > span > a {
+	color:#fff;
+	font-weight: bold;
+}

--- a/assets/code-editor.js
+++ b/assets/code-editor.js
@@ -1,5 +1,5 @@
 /*
-	Copyright (c) 2013, Abram Adams
+	Copyright (c) 2015, Abram Adams
 
 	Licensed under the Apache License, Version 2.0 (the "License");
 	you may not use this file except in compliance with the License.
@@ -345,7 +345,7 @@ angular.module('code.editor', [])
 				aceEditor.resize(true);
 
 				editor.show();
-
+				scope.toggleFullscreen = toggleFullscreen;
 				// Force fullscreen if fullscreen attribute was passed in and true.
 				if( attrs.fullscreen !== undefined && attrs.fullscreen ==	 "true"){
 					toggleFullscreen();
@@ -427,10 +427,10 @@ angular.module('code.editor', [])
 				      	if( scope.setupCodeGist !== undefined && scope.setupCodeGist.length > 0 ){
 				      		url+= '?setupCodeGistId='+ scope.setupCodeGist;
 				      	}
-				      	if( scope.theme.length > 0 ){
+				      	if( scope.theme !== undefined && scope.theme.length > 0 ){
 							url+= (url.indexOf('?') > 0 ? '&' : '?') + 'theme='+ scope.theme;
 				      	}
-				        message.html('<span class="alert alert-success" style="padding: 5px;margin: 5px 0 0 3px;display: inline-block;"><i class="icon-check icon-white"></i> Saved Gist: <a href="http://trycf.com'+ url + '">'+response.id+'</a></span>');
+				        message.html('<span class="alert alert-success" style="padding: 5px;margin: 5px 0 0 3px;display: inline-block;"><i class="icon-check icon-white"></i> Saved Gist: <a href="http://trycf.com'+ url + '" target="_blank">'+response.id+'</a></span>');
 				      })
 				      .error( function(e) {
 				        console.warn("gist save error", e);
@@ -610,22 +610,22 @@ angular.module('code.editor', [])
 				}
 
 				/* UTILITY FUNCTIONS */
-				scope.toggleFullscreen = function(){
+				function toggleFullscreen(){
 
 					element.find( '.editor-container' ).toggleClass( 'fullscreen' );
 					element.find( '.toggle-fullscreen i' ).toggleClass( 'icon-resize-full' ).toggleClass( 'icon-resize-small' );
 
 					if( element.find( '.editor-container' ).hasClass( 'fullscreen' ) ){
-						$( document ).on( 'keyup', scope.handleEscape );
+						$( document ).on( 'keyup', handleEscape );
 					}else{
-						$( document ).off( 'keyup', scope.handleEscape );
+						$( document ).off( 'keyup', handleEscape );
 					}
 					aceEditor.resize(true);
 				}
-				scope.handleEscape = function( e ){
+				function handleEscape( e ){
 					// register listener to restore editor size when escape is pressed
 					if ( e.keyCode == 27 ) { // esc
-						scope.toggleFullscreen();
+						toggleFullscreen();
 					}
 				}
 

--- a/trycf.cfm
+++ b/trycf.cfm
@@ -14,8 +14,10 @@
 <html lang="en" ng-app="trycf">
 <head>
     <cfoutput>
+        <link href="//netdna.bootstrapcdn.com/bootswatch/3.3.5/flatly/bootstrap.min.css" rel="stylesheet">
         <link href="#request.assetBaseURL#vendor/plugins/split-pane/split-pane.css" rel="stylesheet">
         <link href="#request.assetBaseURL#code-editor.css" rel="stylesheet">
+        <link href="#request.assetBaseURL#vendor/font-awesome/font-awesome.css" rel="stylesheet">
     </cfoutput>
 </head>
 <body>
@@ -37,13 +39,14 @@
     		    mode="coldfusion"
     		    width="100%"
     		    height="350px"
+                fullscreen="true"
     		    engine="#encodeForHTMLAttribute(url.engine)#"
     		    show-results="true" code="#htmlEditFormat( example.code )#"></div>
     </cfoutput>
 </cfif>
 
 <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
-
+<script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.5/js/bootstrap.min.js"></script>
 <cfoutput>
 <!--- TryCF Editor Scripts --->
 <!--- Ace Editor --->


### PR DESCRIPTION
With the change to load the trycf editor in a modal on demand there were some supporting assets that were not being loaded (bootstrap css/js, font-awesome), which caused the formatting issues and js errors.  

Also fixed a few editor issues with saving a gist and editor full-screen mode.