### PR TITLE
Addition of script syntax for new Query() function for CF 9-10.

### DIFF
--- a/data/en/cfquery.json
+++ b/data/en/cfquery.json
@@ -61,9 +61,7 @@
 		{
 			"title": "Script Syntax using new Query()",
 			"description": "This syntax was implemented by script-based components in CF 9 & 10. It is superceeded by queryExecute() in CF11.",
-			"code": "queryObj = new Query(\r\n name=\"qryDemo\",\r\n datasource=\"mydatasourcename\",\r\n sql = \"SELECT col1, col2\r\n FROM myTable\r\n WHERE id=:id\"\r\n); \r\nqueryObj.addParam(name=\"id\",value=arguments.id, cfsqltype=\"cf_sql_integer\");\r\nresultset=queryObj.execute().getResult();
-
-			",
+			"code": "queryObj = new Query(\r\n name=\"qryDemo\",\r\n datasource=\"mydatasourcename\",\r\n sql = \"SELECT col1, col2\r\n FROM myTable\r\n WHERE id=:id\"\r\n); \r\nqueryObj.addParam(name=\"id\",value=arguments.id, cfsqltype=\"cf_sql_integer\");\r\nresultset=queryObj.execute().getResult();",
 			"result": ""
 		}
 

--- a/data/en/cfquery.json
+++ b/data/en/cfquery.json
@@ -57,7 +57,17 @@
 			"description":"A dummy query is first created from scratch using queryNew, then sorted. A query of query is performed by specifying dbtype=\"query\" and then using a query object variable name as in the FROM statement.",
 			"code":"<!--- create a dummy query using queryNew --->\n<cfset news = queryNew(\"id,title\", \"integer,varchar\")>\n<cfset queryAddRow(news)>\n<cfset querySetCell(news, \"id\", \"1\")>\n<cfset querySetCell(news, \"title\", \"Dewey defeats Truman\")>\n<cfset queryAddRow(news)>\n<cfset querySetCell(news, \"id\", \"2\")>\n<cfset querySetCell(news, \"title\", \"Men walk on Moon\")>\n<cfset writeDump(news)>\n\n<!--- run QofQ (query of query) --->\n<cfquery name=\"sortedNews\" dbtype=\"query\">\n    SELECT id, title FROM news\n    ORDER BY title DESC\n</cfquery>\n<cfset writeDump(sortedNews)>",
 			"result":""
+		},
+		{
+			"title": "Script Syntax using new Query()",
+			"description": "This syntax was implemented by script-based components in CF 9 & 10. It is superceeded by queryExecute() in CF11.",
+			"code": "queryObj = new Query(\r\n name=\"qryDemo\",\r\n datasource=\"mydatasourcename\",\r\n sql = \"SELECT col1, col2\r\n FROM myTable\r\n WHERE id=:id\"\r\n); \r\nqueryObj.addParam(name=\"id\",value=arguments.id, cfsqltype=\"cf_sql_integer\");\r\nresultset=queryObj.execute().getResult();
+
+			",
+			"result": ""
 		}
+
+
 	]
 
 


### PR DESCRIPTION
This is an example of the script based tag-as-component syntax of making queries in CF9 and 10 prior to the introduction of queryExecute() in 11.