### PR TITLE
Added abort flag to params list

### DIFF
--- a/data/en/writedump.json
+++ b/data/en/writedump.json
@@ -1,7 +1,7 @@
 {
 	"name":"writeDump",
 	"type":"function",
-	"syntax":"writeDump(var [, expand] [, format] [, hide] [, keys] [, label] [, metainfo] [, output] [, show] [, showUDfs] [, top])",
+	"syntax":"writeDump(var [, expand] [, format] [, abort] [, hide] [, keys] [, label] [, metainfo] [, output] [, show] [, showUDfs] [, top])",
 	"returns":"void",
 	"related":[],
 	"description":" Outputs the elements, variables and values of most kinds of\n CFML objects. Useful for debugging. You can display the\n contents of simple and complex variables, objects, components,\n user-defined functions, and other elements.",
@@ -9,6 +9,7 @@
 		{"name":"var","description":"Variable to display. Enclose a variable name in pound\n signs.","required":true,"default":"","type":"variablename","values":[]},
 		{"name":"expand","description":"Yes: In Internet Explorer and Mozilla, expands views","required":false,"default":true,"type":"boolean","values":[true,false]},
 		{"name":"format","description":"specify whether to save the results of a cfdump to a file in text or HTML format","required":false,"default":"text","type":"String","values":["html","text"]},
+		{"name":"abort","description":"Boolean value to immediately abort after displaying the dump.","required": false,"default":false,"type":"boolean","values":[true,false]},
 		{"name":"hide","description":"hide column or keys.","required":false,"default":"","type":"String","values":[]},
 		{"name":"keys","description":"For a structure, number of keys to display.","required":false,"default":"","type":"Numeric","values":[]},
 		{"name":"label","description":"A string; header for the dump output.","required":false,"default":"","type":"String","values":[]},


### PR DESCRIPTION
I thought it valuable to show you can add the abort flag to the writeDump function as opposed to immediately following it with an abort command.