### PR TITLE
Missing examples to menu and bug fix.

### DIFF
--- a/views/doc.cfm
+++ b/views/doc.cfm
@@ -70,9 +70,11 @@
 	  <li class="pull-right">
 	  		<a href="https://github.com/foundeo/cfdocs/issues/new" rel="nofollow" class="label label-warning" title="Report an Issue">Issue</a>
 	  </li>
-	  <li class="pull-right">
-	  		<a href="https://github.com/foundeo/cfdocs#request.gitFilePath#" rel="nofollow" class="label label-danger">Edit</a>
-	  </li>
+      <cfif StructKeyExists(request,"gitFilePath") AND Len(request.gitFilePath)>
+          <li class="pull-right">
+                <a href="https://github.com/foundeo/cfdocs#request.gitFilePath#" rel="nofollow" class="label label-danger">Edit</a>
+          </li>
+      </cfif>
 	</ol>
 </cfif>
 <div class="container">

--- a/views/layout.cfm
+++ b/views/layout.cfm
@@ -63,6 +63,7 @@
             <cfloop list="#listGuides#" index="guide">
                 <li><a href="#linkTo(guide)#">#application.guides[guide]#</a></li>
             </cfloop>
+                <li><a href="/reports/missing-examples.cfm">Missing Examples</a></li>
             </ul>
         </li>
         </cfoutput>


### PR DESCRIPTION
Adding the missing examples page to the "Other" menu and fixing a bug that was preventing reports from showing.