### PR TITLE
highlight current item when stepping through typeahead results

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -40,7 +40,7 @@ h2 .item-name { font-weight:bold; font-family: Menlo,Monaco,Consolas,"Courier Ne
   padding: 3px 20px;
 }
 
-.tt-suggestion:hover {
+.tt-suggestion:hover, .tt-cursor {
   color: #fff;
   cursor: pointer;
   background-color: #0081c2;


### PR DESCRIPTION
This will highlight the current typeahead result when using the arrow
keys to step through typeahead search results (matching the mouse hover
style).