### PR TITLE
Fix markdown links

### DIFF
--- a/Application.cfc
+++ b/Application.cfc
@@ -57,8 +57,8 @@
 		<cfargument name="content">
 		<cfargument name="exclude" default="#url.name#">
 		<cfset var i = "">
-		<cfif ReFindNoCase("https?://", arguments.content)>
-			<cfset arguments.content = ReReplaceNoCase(arguments.content, "(https?://[a-zA-Z0-9._/=&%?##+-]+)", "<a href=""\1"">\1</a>", "ALL")>
+		<cfif ReFindNoCase("[^""]https?://", arguments.content)>
+			<cfset arguments.content = ReReplaceNoCase(arguments.content, "([^""])(https?://[a-zA-Z0-9._/=&%?##+-]+)", "\1<a href=""\2"">\2</a>", "ALL")>
 		</cfif>
 		<cfif ReFindNoCase("\bApplication\.cfc\b", arguments.content)>
 			<cfset arguments.content = ReReplaceNoCase(arguments.content, "\bApplication\.cfc\b", "<a href=""#linkTo('application-cfc')#"">Application.cfc</a>", "ALL")>


### PR DESCRIPTION
Markdown links `[text](url)` get screwed up because the autolink method
replaces links that are already links. This should fix it by only
replacing links that don't have `"` in front of them.