### PR TITLE
Cfmodule

### DIFF
--- a/data/en/cfmodule.json
+++ b/data/en/cfmodule.json
@@ -7,7 +7,7 @@
 	"description":" Invokes a custom tag for use in CFML application pages.\n This tag processes custom tag name conflicts.",
 	"params": [
 		{"name":"template","description":"Mutually exclusive with the name attribute. A path to the\n page that implements the tag.\n\n Relative path: expanded from the current page\n Absolute path: expanded using CFML mapping\n A physical path is not valid.","required":false,"default":"","type":"String","values":[]},
-		{"name":"name","description":"Mutually exclusive with the template attribute. A custom\n tag name, in the form \"Name.Name.Name...\" Identifies\n subdirectory, under the CFML tag root directory,\n that contains custom tag page. For example (Windows format):\n\n <cfmodule name = \"superduper.Forums40.GetUserOptions\">\n\n This identifies the page GetUserOptions.cfm in the\n directory CustomTags\\superduper\\Forums40 under the\n CFML root directory.","required":false,"default":"","type":"String","values":[]},
+		{"name":"name","description":"Mutually exclusive with the template attribute. A custom\n tag name, in the form \"Name.Name.Name...\" Identifies\n subdirectory, under the CFML tag root directory,\n that contains custom tag page. For example (Windows format):\n\n &lt;cfmodule name = \"superduper.Forums40.GetUserOptions\"&gt;\n\n This identifies the page GetUserOptions.cfm in the\n directory CustomTags\\superduper\\Forums40 under the\n CFML root directory.","required":false,"default":"","type":"String","values":[]},
 		{"name":"attributecollection","description":"A collection of key-value pairs that represent\n attribute names and values. You can specify multiple\n key-value pairs. You can specify this attribute only\n once.","required":false,"default":"","type":"Struct","values":[]}
 
 	],
@@ -19,6 +19,44 @@
 	},
 	"links": [
 
-	]
+	],
+  "examples": [
+    {
+      "title": "Using the template attribute with an absolute template path",
+      "description": "",
+      "code": "<cfmodule template=\"\\layout\\default\\mainheader.cfm\">",
+      "result": ""
+    },
+    {
+      "title": "Using the template attribute with a relative template path",
+      "description": "",
+      "code": "<cfmodule template=\"..\\..\\..\\layout\\register\\sectionheader.cfm\">",
+      "result": ""
+    },
+    {
+      "title": "Using the name attribute",
+      "description": "",
+      "code": "<cfmodule name=\"layout.corp.copyright\">",
+      "result": ""
+    },
+    {
+      "title": "Passing two ad-hoc attributes in tag body",
+      "description": "",
+      "code": "<cfmodule template=\"\\layout\\default\\mainheader.cfm\" theme=\"default\" pageTitle=\"Welcome!\">",
+      "result": ""
+    },
+    {
+      "title": "Passing two ad-hoc attributes using the attributeCollection attribute",
+      "description": "",
+      "code": "<cfset attrs = {theme = \"default\", pageTitle = \"Welcome!\"}>\n<cfmodule template=\"\\layout\\default\\mainheader.cfm\" attributecollection=\"#attrs#\">",
+      "result": ""
+    },
+    {
+      "title": "Passing content between opening and closing tags",
+      "description": "In this example, the &lt;p&gt; tag and it's content will be availble to super-duper-formatter.cfm to perform whatever the formatting logic dictates.",
+      "code": "<cfmodule template=\"\\layout\\super-duper-formater.cfm\">\n   <p>Some content the module will format</p>\n</cfmodule>",
+      "result": ""
+    }
+  ]
 
 }

--- a/data/en/cfmodule.json
+++ b/data/en/cfmodule.json
@@ -25,37 +25,43 @@
       "title": "Using the template attribute with an absolute template path",
       "description": "",
       "code": "<cfmodule template=\"\\layout\\default\\mainheader.cfm\">",
-      "result": ""
+      "result": "",
+      "runnable" : false
     },
     {
       "title": "Using the template attribute with a relative template path",
       "description": "",
       "code": "<cfmodule template=\"..\\..\\..\\layout\\register\\sectionheader.cfm\">",
-      "result": ""
+      "result": "",
+      "runnable" : false
     },
     {
       "title": "Using the name attribute",
       "description": "",
       "code": "<cfmodule name=\"layout.corp.copyright\">",
-      "result": ""
+      "result": "",
+      "runnable" : false
     },
     {
       "title": "Passing two ad-hoc attributes in tag body",
       "description": "",
       "code": "<cfmodule template=\"\\layout\\default\\mainheader.cfm\" theme=\"default\" pageTitle=\"Welcome!\">",
-      "result": ""
+      "result": "",
+      "runnable" : false
     },
     {
       "title": "Passing two ad-hoc attributes using the attributeCollection attribute",
       "description": "",
       "code": "<cfset attrs = {theme = \"default\", pageTitle = \"Welcome!\"}>\n<cfmodule template=\"\\layout\\default\\mainheader.cfm\" attributecollection=\"#attrs#\">",
-      "result": ""
+      "result": "",
+      "runnable" : false
     },
     {
       "title": "Passing content between opening and closing tags",
       "description": "In this example, the &lt;p&gt; tag and it's content will be availble to super-duper-formatter.cfm to perform whatever the formatting logic dictates.",
       "code": "<cfmodule template=\"\\layout\\super-duper-formater.cfm\">\n   <p>Some content the module will format</p>\n</cfmodule>",
-      "result": ""
+      "result": "",
+      "runnable" : false
     }
   ]
 


### PR DESCRIPTION
Added examples for <cfmodule> tag. Bug fix for unescaped angle brackets in attribute reference section for "name" attribute.