### PR TITLE
deserializeJSON() replace escaped double quotes

### DIFF
--- a/data/en/deserializejson.json
+++ b/data/en/deserializejson.json
@@ -23,9 +23,8 @@
 		{
 			"title":"Convert JSON into CF Structure",
 			"description":"",
-			"code":"person = deserializeJSON(\"{\"\"company\"\":\"\"Foundeo\"\",\"\"name\"\":\"\"Pete Freitag\"\"}\");\nwriteOutput( person.company );",
+			"code":"person = deserializeJSON( '{\"company\":\"Foundeo\",\"name\":\"Pete Freitag\"}' );\r\nwriteOutput( person.company );",
 			"result": "Foundeo"
 		}
 	]
-
 }


### PR DESCRIPTION
I agree with Adam
(http://blog.adamcameron.me/2016/01/coldfusion-how-not-to-document-function.html)
this makes the example more focused.