### PR TITLE
Adding dateTimeFormat to function listing pages.

### DIFF
--- a/data/en/date-and-time-functions.json
+++ b/data/en/date-and-time-functions.json
@@ -1,6 +1,6 @@
 {
 	"name":"Date / Time Functions",
 	"type":"listing",
-	"related":["createDate","createDateTime","createODBCDate","createODBCDateTime","createODBCTime","createTime","createTimespan","dateAdd","dateCompare","dateConvert","dateDiff","dateFormat","datePart","day","dayOfWeek","dayOfWeekAsString","dayOfWeekShortAsString","dayOfYear","daysInMonth","daysInYear","firstDayOfMonth","getHTTPTimeString","getNumericDate","getTickCount","getTimezone","getTimezoneInfo","hour","isDate","isLeapYear","isNumericDate","LSDateFormat","LSDayOfWeek","LSIsDate","LSParseDateTime","LSTimeFormat","minute","month","monthAsString","monthShortAsString","now","parseDateTime","quarter","second","setTimezone","timeFormat","year"],
+	"related":["createDate","createDateTime","createODBCDate","createODBCDateTime","createODBCTime","createTime","createTimespan","dateAdd","dateCompare","dateConvert","dateDiff","dateFormat","datePart","dateTimeFormat","day","dayOfWeek","dayOfWeekAsString","dayOfWeekShortAsString","dayOfYear","daysInMonth","daysInYear","firstDayOfMonth","getHTTPTimeString","getNumericDate","getTickCount","getTimezone","getTimezoneInfo","hour","isDate","isLeapYear","isNumericDate","LSDateFormat","LSDayOfWeek","LSIsDate","LSParseDateTime","LSTimeFormat","minute","month","monthAsString","monthShortAsString","now","parseDateTime","quarter","second","setTimezone","timeFormat","year"],
 	"description":"A listing of CFML Date / Time Functions."
 }

--- a/data/en/formatting-functions.json
+++ b/data/en/formatting-functions.json
@@ -1,6 +1,6 @@
 {
 	"name":"Formatting Functions",
 	"type":"listing",
-	"related":["cJustify","dateFormat","decimalFormat","dollarFormat","formatBaseN","getLocale","getLocaleDisplayName","htmlCodeFormat","htmlEditFormat","lJustify","lsCurrencyFormat","lsDateFormat","lsEuroCurrencyFormat","lsIsCurrency","lsIsDate","lsNumberFormat","LSParseCurrency","LSParseDateTime","LSParseEuroCurrency","LSParseNumber","lsTimeFormat","numberFormat","paragraphFormat","rJustify","stripCR","timeFormat","urlEncodedFormat","urlSessionFormat","xmlFormat","yesNoFormat"],
+	"related":["cJustify","dateFormat","dateTimeFormat","decimalFormat","dollarFormat","formatBaseN","getLocale","getLocaleDisplayName","htmlCodeFormat","htmlEditFormat","lJustify","lsCurrencyFormat","lsDateFormat","lsEuroCurrencyFormat","lsIsCurrency","lsIsDate","lsNumberFormat","LSParseCurrency","LSParseDateTime","LSParseEuroCurrency","LSParseNumber","lsTimeFormat","numberFormat","paragraphFormat","rJustify","stripCR","timeFormat","urlEncodedFormat","urlSessionFormat","xmlFormat","yesNoFormat"],
 	"description":"A listing of CFML Formatting Functions."
 }


### PR DESCRIPTION
Just adding dateTimeFormat to the date-and-time functions and the formatting functions. 