### PR TITLE
Fix link to ArrayFindAll

### DIFF
--- a/guides/en/closures.md
+++ b/guides/en/closures.md
@@ -282,7 +282,7 @@ http://taha-sh.com/blog/understanding-closures-in-javascript
 * [ArrayFilter](/arrayfilter)
 * [StructFilter](/structfilter)
 * [ListFilter](/ListFilter)
-* [ArrayFindAt ](/ArrayFindAt)
+* [ArrayFindAll ](/ArrayFindAll)
 * [ArrayFindAllNoCase](/ArrayFindAllNoCase)
   
 


### PR DESCRIPTION
Link was pointing to "/ArrayFindAt" which doesn't exist. I suspect that was meant to be "/ArrayFindAll"