### PR TITLE
Just making the tag syntax equivalent to the script syntax.

### DIFF
--- a/data/en/cflocation.json
+++ b/data/en/cflocation.json
@@ -1,7 +1,7 @@
 {
 	"name":"cflocation",
 	"type":"tag",
-	"syntax":"<cflocation url=\"page.cfm\" addtoken=\"false\">",
+	"syntax":"<cflocation url=\"page.cfm\" addtoken=\"false\" statusCode=\"301\">",
 	"script":"location(\"mypage.cfm\", \"false\", \"301\");",
 	"returns":"",
 	"related":[],


### PR DESCRIPTION
I see that the full syntax for both is demonstrated in the code examples at the bottom, but the top examples implied to me (at first glance) that the tag version does not have the `statusCode` attribute.