### PR TITLE
htmlEditFormat(): added deprecated and cleanup

### DIFF
--- a/data/en/htmleditformat.json
+++ b/data/en/htmleditformat.json
@@ -1,32 +1,51 @@
 {
-	"name":"HTMLEditFormat",
-	"type":"function",
-	"syntax":"HTMLEditFormat(String [, version])",
-	"returns":"String",
-	"related":[],
-	"description":" Replaces special characters in a string with their\n HTML-escaped equivalents.\n [version]\n HTML version to use. currently ignored.\n -1: The latest implementation of HTML\n 2.0: HTML 2.0 (Default)\n 3.2: HTML 3.2",
-	"params": [
-		{"name":"String","description":"","required":true,"default":"","type":"String","values":[]},
-		{"name":"version","description":"","required":false,"default":"","type":"Numeric","values":[-1,2.0,3.2]}
+  "name": "HTMLEditFormat",
+  "type": "function",
+  "returns": "string",
+  "syntax": "HTMLEditFormat( string [, version] )",
+  "description": "Replaces special characters in a string with their HTML-escaped equivalents.",
+  "params": [
+    {
+      "name": "string",
+      "required": true,
+      "default": "",
+      "description": "A string or a variable that contains one.",
+      "type": "string",
+      "values": []
+    },
+    {
+      "name": "version",
+      "required": false,
+      "default": "",
+      "description": "HTML version to use; currently ignored.",
+      "type": "numeric",
+      "values": [ -1, 2.0, 3.2 ]
+    }
+  ],
 
-	],
-	"engines": {
-		"coldfusion": {"minimum_version":"", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-h-im/htmleditformat.html"},
-		"lucee": {"minimum_version":"", "notes":"", "docs":"http://docs.lucee.org/reference/functions/htmleditformat.html"},
-		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/function/htmleditformat"},
-		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/function/htmleditformat"}
-	},
-	"links": [
+  "engines": {
+    "coldfusion": { "docs": "https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-h-im/htmleditformat.html",
+      "minimum_version": "", "notes": "\nUse encodeForHTML, which can provide more protection from XSS.", "deprecated" : 11 },
+    "lucee":      { "docs": "http://docs.lucee.org/reference/functions/htmleditformat.html",
+      "minimum_version": "", "notes": "" },
+    "openbd":     { "docs": "http://openbd.org/manual/?/function/htmleditformat",
+      "minimum_version": "", "notes": "" },
+    "railo":      { "docs": "http://railodocs.org/index.cfm/function/htmleditformat",
+      "minimum_version": "", "notes": "" }
+  },
 
-	],
-    "examples": [
-		{
-			"title": "Tag Syntax",
-			"description": "",
-			"code": "<cfset testString=\"This is a test & this is another <This text is in angle brackets> Previous line was blank!!!\">   <cfoutput>#HTMLEditFormat(testString)# </cfoutput>   ",
-			"result": "",
-			"runnable":true
-		}
-	]
+  "examples": [
+    {
+      "title": "",
+      "description": "Escapes the HTML characters",
+      "code": "HTMLEditFormat( \"This is a test & this is another <This text is in angle brackets> Previous line was blank!!!\" )",
+      "result": "This is a test &amp; this is another &lt;This text is in angle brackets&gt; Previous line was blank!!!",
+      "runnable": true
+    }
+  ],
 
+  "links": [],
+  "related": [
+    "encodeForHTML"
+  ]
 }

--- a/views/doc.cfm
+++ b/views/doc.cfm
@@ -35,7 +35,7 @@
             </cfif>
         </cfif>
 	</cfif>
-    
+
     <cfif structKeyExists(data, "engines") AND structKeyExists(data.engines, "coldfusion") AND structKeyExists(data.engines.coldfusion, "deprecated") AND len(data.engines.coldfusion.deprecated)>
 
     	<div class="alert alert-danger">
@@ -52,14 +52,14 @@
         </div>
     <cfelseif StructKeyExists(data, "engines") AND structCount(data.engines) EQ 1>
     	<div class="alert alert-warning">
-            This <cfif data.type IS "tag">tag<cfelseif data.type IS "function">function</cfif> requires 
-            	<cfif structKeyExists(data.engines, "coldfusion")> 
+            This <cfif data.type IS "tag">tag<cfelseif data.type IS "function">function</cfif> requires
+            	<cfif structKeyExists(data.engines, "coldfusion")>
             		Adobe ColdFusion<cfif StructKeyExists(data.engines.coldfusion, "minimum_version") AND Len(data.engines.coldfusion.minimum_version)> #data.engines.coldfusion.minimum_version# and up</cfif>.
             		 <em> Not supported on Lucee, OpenBD, etc.</em>
             	<cfelseif structKeyExists(data.engines, "lucee")>
-            		Lucee. <em>Not supported on Adobe ColdFusion.</em> 
+            		Lucee. <em>Not supported on Adobe ColdFusion.</em>
             	</cfif>
-            
+
         </div>
     </cfif>
     <cfif StructKeyExists(data, "discouraged") AND Len(data.discouraged)>
@@ -147,7 +147,7 @@
 							#autoLink(p.description)#
 							<cfif StructKeyExists(p, "values") AND IsArray(p.values) AND ArrayLen(p.values)>
 								<cfif uCase(arrayToList(p.values)) IS NOT "YES,NO">
-									
+
 									<ul>
 										<cfloop array="#p.values#" index="i">
 											<li><code>#XmlFormat(i)#</code></li>
@@ -168,28 +168,29 @@
 				<cfsavecontent variable="compatibilityData">
 					#compatibilityData#
 					<div class="row">
-					<div class="col-xs-2 text-right">
-						<h4>
-							<cfif i IS "coldfusion">ColdFusion<cfelseif i IS "railo">Railo<cfelseif i IS "openbd">OpenBD<cfelseif i IS "lucee">Lucee</cfif>: 						
-						</h4>
-					</div>
-					<div class="col-xs-8">
-						<cfif StructKeyExists(data.engines[i], "deprecated") AND Len(data.engines[i].deprecated)>
-							<div class="alert alert-danger">
-								<strong>DEPRECATED</strong> since version #encodeForHTML(data.engines[i].deprecated)#
-								<cfif StructKeyExists(data.engines[i], "removed") AND Len(data.engines[i].removed)>
-									<strong>REMOVED</strong> in version #encodeForHTML(data.engines[i].removed)#
-								</cfif>
-								<cfif StructKeyExists(data.engines[i], "notes") AND Len(data.engines[i].notes)>
+						<div class="col-xs-2 text-right">
+							<h4>
+								<cfif i IS "coldfusion">ColdFusion<cfelseif i IS "railo">Railo<cfelseif i IS "openbd">OpenBD<cfelseif i IS "lucee">Lucee</cfif>:
+							</h4>
+						</div>
+						<div class="col-xs-8">
+							<cfif StructKeyExists(data.engines[i], "deprecated") AND Len(data.engines[i].deprecated)>
+								<div class="alert alert-danger">
+									<strong>DEPRECATED</strong> since version #encodeForHTML(data.engines[i].deprecated)#
+									<cfif StructKeyExists(data.engines[i], "removed") AND Len(data.engines[i].removed)>
+										<strong>REMOVED</strong> in version #encodeForHTML(data.engines[i].removed)#
+									</cfif>
+									<cfif StructKeyExists(data.engines[i], "notes") AND Len(data.engines[i].notes)>
+										#autoLink(XmlFormat(data.engines[i].notes))#
+									</cfif>
+								</div>
+							<cfelse>
+								<div class="alert alert-warning">
+									<cfif Len(data.engines[i].minimum_version)><span class="label label-danger">Version #XmlFormat(data.engines[i].minimum_version)#+</span></cfif>
 									#autoLink(XmlFormat(data.engines[i].notes))#
-								</cfif>
-							</div>
-						<cfelse>
-							<div class="alert alert-warning">
-								<cfif Len(data.engines[i].minimum_version)><span class="label label-danger">Version #XmlFormat(data.engines[i].minimum_version)#+</span></cfif>
-								#autoLink(XmlFormat(data.engines[i].notes))#</div>
-							</div>
-						</cfif>
+								</div>
+							</cfif>
+						</div>
 					</div>
 				</cfsavecontent>
 			</cfif>
@@ -213,7 +214,7 @@
         <cfset example_index = 0>
 		<cfloop array="#data.examples#" index="ex">
             <cfset example_index = example_index + 1>
-            
+
 			<br />
 			<h4 id="ex#example_index#">
                 #XmlFormat(ex.title)#


### PR DESCRIPTION
also: fixed a </div> that was in the wrong place on doc.cfm (at the end
of the Compatibility section)
