### PR TITLE
homepage: responsive fix for contributors section

### DIFF
--- a/views/index.cfm
+++ b/views/index.cfm
@@ -29,6 +29,7 @@
       <cfif statResult.statusCode contains "200" AND IsJSON(statResult.fileContent)>
         <cfset stats = DeserializeJSON(statResult.fileContent)>
         <h2 class="text-center"><cfoutput>#ArrayLen(stats)#</cfoutput> Awesome Contributors <br><small>The Leader Board</small></h2>
+          <div class="row">
             <!--- seams to be in reverse order --->
             <cfset i = 0>
             <cfloop from="#ArrayLen(stats)#" to="1" index="s" step="-1">
@@ -54,18 +55,17 @@
                 </cfloop>
               </cfsilent>
               <cfoutput>
-              <div class="contributor">
-                <div class="row">
-                  <div class="col-sm-4 text-center">
-                    <a href="#encodeForHTMLAttribute(stat.author.html_url)#" rel="nofollow"><img src="#encodeForHTMLAttribute(stat.author.avatar_url)#" class="img-rounded" height="75" width="75" /></a> 
-                    <br>
+              <div class="col-xs-12 col-sm-6 col-md-4">
+                <div class="contributor row">
+                  <div class="col-xs-5 text-center">
+                    <a href="#encodeForHTMLAttribute(stat.author.html_url)#" rel="nofollow"><img src="#encodeForHTMLAttribute(stat.author.avatar_url)#" class="img-rounded" /></a> 
                     <div class="text-muted"><strong>#encodeForHTML(stat.author.login)#</strong></div>
                   </div>
-                  <div class="col-sm-4">
+                  <div class="col-xs-7">
                     
                     <span class="label label-primary">#Val(stat.total)# Contribution<cfif Val(stat.total) NEQ 1>s</cfif></span><br>
                     
-                    <span class="label label-info">#Val(a+d)# Line<cfif Val(a+d) NEQ 1>s</cfif> Altered</span>
+                    <span class="label label-info">#Val(a+d)# Line<cfif Val(a+d) NEQ 1>s</cfif> Altered</span><br>
                     <cfset weeksAgo = DateDiff("w", DateAdd("s", lastMod, "1970-01-01 00:00:00"), now())>
                     <span class="label label-success"><cfif weeksAgo EQ 0>Contributed this week!<cfelse>#weeksAgo# week<cfif weeksAgo NEQ 1>s</cfif> ago</cfif></span>
                   </div>
@@ -75,13 +75,15 @@
               </cfoutput>
             </cfloop> 
        
+          </div>
       <cfelse>
         <!--- error connecting to github so tell CDN to only cache for 30 seconds --->
         <cfset request.cacheControlMaxAge = 30> 
       </cfif>
   
     <style>
-        .contributor { width: 320px; display:inline-block; background-color: #f1f1f1; border-radius: 7px; margin: 5px 20px; padding:15px 10px; }
+        .contributor { background-color: #f1f1f1; border-radius: 7px; margin: 5px 0; padding:15px 10px; }
+        .contributor img { width: 75px; height: 75px; display: block; margin: 0 auto; }
         #test-tool { text-align: center;}
     </style>
     <cfcatch>


### PR DESCRIPTION
A couple of fixes for the homepage, so the contributors section looks
better on tablets (2 col) and phones (1 col).