### PR TITLE
Added param unsynchronized

### DIFF
--- a/data/en/arraynew.json
+++ b/data/en/arraynew.json
@@ -4,9 +4,10 @@
 	"syntax":"arrayNew(dimension)",
 	"returns":"Array",
 	"related":[],
-	"description":" Creates an array of 1-3 dimensions. Index array elements\n with square brackets: [ ].\n CFML arrays expand dynamically as data is added.",
+	"description":" Creates an array of 1-3 dimensions. Index array elements\n with square brackets: [ ].\n CFML arrays expand dynamically as data is added.\n\nThe param unsynchronized is only available in ACF 2016!",
 	"params": [
-		{"name":"dimension","description":"","required":true,"default":1,"type":"Numeric","values":[1]}
+		{"name":"dimension","description":"","required":true,"default":1,"type":"Numeric","values":[1]},
+		{"name":"unsynchronized)","description":" Users can create unsynchronized arrays by passing a special flag","required":false,"default":false,"type":"Boolean","values":[1]}
 
 	],
 	"engines": {
@@ -29,6 +30,12 @@
 			"description": "Uses the arrayNew function to create the new array",
 			"code": "newArray = arrayNew(2);\nnewArray[1][1] = \"First value\";\nnewArray[1][1] = \"First value\";\nnewArray[1][2] = \"First value\";\nnewArray[2][1] = \"Second value\";\nnewArray[2][2] = \"Second value\";\nwriteOutput( serializeJSON(newArray) );",
 			"result": "[[\"First value\", \"First value\"],[\"Second value\", \"Second value\"]]"
+		},
+		{
+			"title": "Create unsynchronized array",
+			"description": "Uses the arrayNew function to create the new unsynchronized array",
+			"code": "newArray = arrayNew(1, true); newArray = [ 1, 2 ]",
+			"result": "[ 1, 2 ]"
 		}
 	]
 


### PR DESCRIPTION
From the Adobe documentation:

Unsynchronized arrays
The 2016 release of ColdFusion comes with support for unsynchronized arrays. Users can create
unsynchronized arrays by passing a special flag to arrayNew method. By default, the arrays are
synchronized for backward compatibility. Unsynchronized arrays are about 93% faster due to lock
avoidance. Please note that they are not thread safe. You should use them when you do not need thread
safety.
Sample code to create an unsynchronized array:
ar_obj = arrayNew(numeric dimension, boolean unsynchronized);