### PR TITLE
For #356, fix lucee compat warning for StructMap

### DIFF
--- a/data/en/structmap.json
+++ b/data/en/structmap.json
@@ -1,7 +1,8 @@
 {"syntax":"structMap(struct, function(key, value [,struct]))",
 "description":"Iterates over every entry of the Struct and calls the closure function to work on the key value pair of the struct. The returned value will be set for the same key in a new struct and the new struct will be returned.",
-"engines":
-    {"coldfusion":{"minimum_version":"11","docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-s/structmap.html","notes":""}
+"engines":{
+    "coldfusion":{"minimum_version":"11","docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-s/structmap.html","notes":""},
+    "lucee":{"minimum_version":"4.5", "docs":"http://docs.lucee.org/reference/functions/structmap.html","notes":""}
 },
 "name":"structMap",
 "links":[],


### PR DESCRIPTION
I couldn't find any docs on minimum version of Lucee for this function so I just guessed 4.5