### PR TITLE
Added date member functions

### DIFF
--- a/data/en/createodbcdate.json
+++ b/data/en/createodbcdate.json
@@ -2,6 +2,7 @@
 	"name":"createODBCDate",
 	"type":"function",
 	"syntax":"createODBCDate(date)",
+	"member":"date.createODBCDate()",
 	"returns":"ODBCDate",
 	"related":["CreateDate","CreateODBCDateTime"],
 	"description":" Creates an ODBC date object.",
@@ -10,8 +11,8 @@
 
 	],
 	"engines": {
-		"coldfusion": {"minimum_version":"", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-c-d/CreateODBCDate.html"},
-		"lucee": {"minimum_version":"", "notes":"", "docs":"http://docs.lucee.org/reference/functions/createodbcdate.html"},
+		"coldfusion": {"minimum_version":"", "notes":"Member function is available in CF11+.", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-c-d/CreateODBCDate.html"},
+		"lucee": {"minimum_version":"", "notes":"Member function is not available.", "docs":"http://docs.lucee.org/reference/functions/createodbcdate.html"},
 		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/function/createodbcdate"},
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/function/createodbcdate"}
 	},

--- a/data/en/createodbcdatetime.json
+++ b/data/en/createodbcdatetime.json
@@ -2,6 +2,7 @@
 	"name":"createODBCDateTime",
 	"type":"function",
 	"syntax":"createODBCDateTime(date)",
+	"member":"date.createODBCDateTime()",
 	"returns":"ODBCDateTime",
 	"related":["CreateDateTime", "CreateODBCDate", "CreateODBCTime", "Now"],
 	"description":" Creates an ODBC date-time object.",
@@ -10,8 +11,8 @@
 
 	],
 	"engines": {
-		"coldfusion": {"minimum_version":"", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-c-d/CreateODBCDateTime.html"},
-		"lucee": {"minimum_version":"", "notes":"", "docs":"http://docs.lucee.org/reference/functions/createodbcdatetime.html"},
+		"coldfusion": {"minimum_version":"", "notes":"Member function is available in CF11+.", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-c-d/CreateODBCDateTime.html"},
+		"lucee": {"minimum_version":"", "notes":"Member function is not available.", "docs":"http://docs.lucee.org/reference/functions/createodbcdatetime.html"},
 		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/function/createodbcdatetime"},
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/function/createodbcdatetime"}
 	},

--- a/data/en/createodbctime.json
+++ b/data/en/createodbctime.json
@@ -2,6 +2,7 @@
 	"name":"createODBCTime",
 	"type":"function",
 	"syntax":"createODBCTime(date)",
+	"member":"date.createODBCTime()",
 	"returns":"ODBCTime",
 	"related":["CreateODBCDateTime", "CreateTime"],
 	"description":" Creates an ODBC time object.",
@@ -10,8 +11,8 @@
 
 	],
 	"engines": {
-		"coldfusion": {"minimum_version":"", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-c-d/CreateODBCTime.html"},
-		"lucee": {"minimum_version":"", "notes":"", "docs":"http://docs.lucee.org/reference/functions/createodbctime.html"},
+		"coldfusion": {"minimum_version":"", "notes":"Member function is available in CF11+.", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-c-d/CreateODBCTime.html"},
+		"lucee": {"minimum_version":"", "notes":"Member function is not available.", "docs":"http://docs.lucee.org/reference/functions/createodbctime.html"},
 		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/function/createodbctime"},
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/function/createodbctime"}
 	},

--- a/data/en/dateadd.json
+++ b/data/en/dateadd.json
@@ -2,6 +2,7 @@
 	"name":"dateAdd",
 	"type":"function",
 	"syntax":"dateAdd(datepart, number, date)",
+	"member":"date.add(datepart, number)",
 	"returns":"DateTime",
 	"related":["now","DateConvert","DatePart","CreateTimeSpan","CreateDate"],
 	"description":" Adds units of time to a date.",
@@ -12,8 +13,8 @@
 	],
 	"returns":"Date/Time Object",
 	"engines": {
-		"coldfusion": {"minimum_version":"", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-c-d/DateAdd.html"},
-		"lucee": {"minimum_version":"", "notes":"", "docs":"http://docs.lucee.org/reference/functions/dateadd.html"},
+		"coldfusion": {"minimum_version":"", "notes":"Member function is available in CF11+.", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-c-d/DateAdd.html"},
+		"lucee": {"minimum_version":"", "notes":"Member function is available in Lucee4.5+", "docs":"http://docs.lucee.org/reference/functions/dateadd.html"},
 		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/function/dateadd"},
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/function/dateadd"}
 	},

--- a/data/en/dateconvert.json
+++ b/data/en/dateconvert.json
@@ -2,6 +2,7 @@
 	"name":"dateConvert",
 	"type":"function",
 	"syntax":"dateConvert(type, date)",
+	"member":"date.convert(type)",
 	"returns":"DateTime",
 	"related":["Now","CreateDateTime"],
 	"description":" Converts local time to Coordinated Universal Time (UTC),\n or UTC to local time. The function uses the daylight savings\n settings in the executing computer to compute daylight\n savings time, if required. ",
@@ -11,8 +12,8 @@
 
 	],
 	"engines": {
-		"coldfusion": {"minimum_version":"4", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-c-d/DateConvert.html"},
-		"lucee": {"minimum_version":"", "notes":"", "docs":"http://docs.lucee.org/reference/functions/dateconvert.html"},
+		"coldfusion": {"minimum_version":"4", "notes":"Member function is available in CF11+.", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-c-d/DateConvert.html"},
+		"lucee": {"minimum_version":"", "notes":"Member function is not available.", "docs":"http://docs.lucee.org/reference/functions/dateconvert.html"},
 		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/function/dateconvert"},
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/function/dateconvert"}
 	},

--- a/data/en/datediff.json
+++ b/data/en/datediff.json
@@ -2,6 +2,7 @@
 	"name":"dateDiff",
 	"type":"function",
 	"syntax":"dateDiff(datepart, date1, date2)",
+	"member":"date1.diff(datepart, date2)",
 	"returns":"Numeric",
 	"related":["dateadd","dateformat"],
 	"description":"Determines the integer number of units by which date1 is less than date2.",
@@ -12,8 +13,8 @@
 
 	],
 	"engines": {
-		"coldfusion": {"minimum_version":"", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-c-d/DateDiff.html"},
-		"lucee": {"minimum_version":"", "notes":"", "docs":"http://docs.lucee.org/reference/functions/datediff.html"},
+		"coldfusion": {"minimum_version":"", "notes":"Member function is available in CF11+.", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-c-d/DateDiff.html"},
+		"lucee": {"minimum_version":"", "notes":"Member function is available in Lucee4.5+. The Lucee member function diffs dates in the opposite direction (+/-) than the Adobe CF member function. See the example below.", "docs":"http://docs.lucee.org/reference/functions/datediff.html"},
 		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/function/datediff"},
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/function/datediff"}
 	},
@@ -31,6 +32,11 @@
 			"title": "How old are they?",
 			"description": "Calculates a persons age based on a variable birthDate which contains a date. Uses the now function to get current date.",
 			"code": "dateDiff(\"yyyy\", birthDate, now())"
+		},
+		{
+			"title": "dateDiff member function",
+			"description": "Note the different behavior between ColdFusion and Lucee.",
+			"code": "testDate = now();\ndiffDate = dateAdd('d', 1, testDate);\nwriteOutput(testDate.diff('d', diffDate)); // this returns 1 on Lucee, and -1 on ColdFusion"
 		}
 	]
 

--- a/data/en/dateformat.json
+++ b/data/en/dateformat.json
@@ -2,6 +2,7 @@
 	"name":"dateFormat",
 	"type":"function",
 	"syntax":"dateFormat(date [, mask])",
+	"member":"date.dateFormat([mask])",
 	"returns":"String",
 	"related":["timeFormat","dateTimeFormat"],
 	"description":"Formats a date value using U.S. date formats. When formatting both date and time, use DateTimeFormat. For international date support, use LSDateFormat.\n [mask - quicky]\n d,dd,ddd,dddd: Day of month / week\n m,mm,mmm,mmmm: Month\n y,yy,yyyy: Year\n gg: Period/era string\n short / medium / long / full",
@@ -11,8 +12,8 @@
 
 	],
 	"engines": {
-		"coldfusion": {"minimum_version":"", "notes":"CF6+ Added support for the `short`, `medium`, `long` and `full` mask formats.", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-c-d/DateFormat.html"},
-		"lucee": {"minimum_version":"", "notes":"", "docs":"http://docs.lucee.org/reference/functions/dateformat.html"},
+		"coldfusion": {"minimum_version":"", "notes":"CF6+ Added support for the `short`, `medium`, `long` and `full` mask formats. Member function is available in CF11+.", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-c-d/DateFormat.html"},
+		"lucee": {"minimum_version":"", "notes":"Member function is available in Lucee4.5+.", "docs":"http://docs.lucee.org/reference/functions/dateformat.html"},
 		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/function/dateformat"},
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/function/dateformat"}
 	},

--- a/data/en/datepart.json
+++ b/data/en/datepart.json
@@ -2,6 +2,7 @@
 	"name":"datePart",
 	"type":"function",
 	"syntax":"datePart(datepart, date)",
+	"member":"date.datePart(datepart)",
 	"returns":"Numeric",
 	"related":[],
 	"description":" Extracts a part from a date value as a numeric.\n [datepart - quicky]\n yyyy: Year; q: Quarter; m: Month; y: Day of year; d: Day\n w: Weekday; ww: Week; h: Hour; n: Minute; s: Second;\n l: Millisecond",
@@ -11,8 +12,8 @@
 
 	],
 	"engines": {
-		"coldfusion": {"minimum_version":"", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-c-d/DatePart.html"},
-		"lucee": {"minimum_version":"", "notes":"", "docs":"http://docs.lucee.org/reference/functions/datepart.html"},
+		"coldfusion": {"minimum_version":"", "notes":"Member function is available is CF11+.", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-c-d/DatePart.html"},
+		"lucee": {"minimum_version":"", "notes":"Member function is available is Lucee4.5+. The syntax for this member function is `date.part(datepart)`.", "docs":"http://docs.lucee.org/reference/functions/datepart.html"},
 		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/function/datepart"},
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/function/datepart"}
 	},

--- a/data/en/datetimeformat.json
+++ b/data/en/datetimeformat.json
@@ -2,6 +2,7 @@
 	"name":"dateTimeFormat",
 	"type":"function",
 	"syntax":"dateTimeFormat(dateTime [, mask] [, timezone])",
+	"member":"datetime.dateTimeFormat([mask] [, timezone])",
 	"returns":"String",
 	"related":["dateFormat","timeFormat"],
 	"description":" Formats a datetime value using U.S. date and time formats. For international date support, use LSDateTimeFormat.\n[mask - quicky]\nd: Day of the month as digits; no leading zero for single-digit days.\ndd: Day of the month as digits; leading zero for single-digit days.\nEEE: Day of the week as a three-letter abbreviation.\nEEEE: Day of the week as its full name.\nm: Month as digits; no leading zero for single-digit months.\nmm: Month as digits; leading zero for single-digit months.\nmmm: Month as a three-letter abbreviation.\nmmmm: Month as its full name.\nyy: Year as last two digits; leading zero for years less than 10.\nyyyy: Year represented by four digits.\n Y YY: Week Year\nG: Period/era string.\nh: hours; no leading zero for single-digit hours (12-hour clock)\nhh: hours; leading zero for single-digit hours (12-hour clock)\nH: hours; no leading zero for single-digit hours (24-hour clock)\nHH: hours; leading zero for single-digit hours (24-hour clock)\nn: minutes; no leading zero for single-digit minutes\nnn: minutes; a leading zero for single-digit minutes\ns: seconds; no leading zero for single-digit seconds\nss: seconds; leading zero for single-digit seconds\nl or L: milliseconds, with no leading zeros\nt: one-character time marker string, such as A or P\ntt: multiple-character time marker string, such as AM or PM",
@@ -11,8 +12,8 @@
 		{"name":"timezone","description":"The timezone to use. Can be 3 letter code (UTC) or full America/New_York","required":false,"default":"","type":"String","values":["UTC","GMT","America/Chicago"]}
 	],
 	"engines": {
-		"coldfusion": {"minimum_version":"10", "notes":"ColdFusion 10 added this function.", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-c-d/DateTimeFormat.html"},
-		"lucee": {"minimum_version":"4.5", "notes":"The timezone argument does not appear to convert the date from the system timezone to the specified timezone as it does in ACF.", "docs":"http://docs.lucee.org/reference/functions/datetimeformat.html"},
+		"coldfusion": {"minimum_version":"10", "notes":"ColdFusion 10 added this function. Member function is available in CF11+.", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-c-d/DateTimeFormat.html"},
+		"lucee": {"minimum_version":"4.5", "notes":"The timezone argument does not appear to convert the date from the system timezone to the specified timezone as it does in ACF. Member function is not available.", "docs":"http://docs.lucee.org/reference/functions/datetimeformat.html"},
 		"railo": {"minimum_version":"4.0.1", "notes":"No documentation exists for this function on Railo, however LSDateTimeFormat is documented. Follows Java date time mask. For details, see the section Date and Time Patterns at the following URL: http://docs.oracle.com/javase/1.4.2/docs/api/java/text/SimpleDateFormat.html ", "docs":"http://railodocs.org/index.cfm/function/lsdateformat"},
 		"openbd": {"minimum_version":"", "notes":"Some of the mask tokens differ from Adobe ColdFusion", "docs":"http://openbd.org/manual/?/function/datetimeformat"}
 	},

--- a/data/en/day.json
+++ b/data/en/day.json
@@ -2,6 +2,7 @@
 	"name":"day",
 	"type":"function",
 	"syntax":"day(date)",
+	"member":"date.day()",
 	"returns":"Numeric",
 	"related":["DayOfWeek", "DayOfWeekAsString", "DayOfYear", "DaysInMonth", "DaysInYear", "FirstDayOfMonth"],
 	"description":" Determines the day of the month, in a date.\n The ordinal for the day of the month, ranging from 1 to 31.",
@@ -10,8 +11,8 @@
 
 	],
 	"engines": {
-		"coldfusion": {"minimum_version":"", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-c-d/Day.html"},
-		"lucee": {"minimum_version":"", "notes":"", "docs":"http://docs.lucee.org/reference/functions/day.html"},
+		"coldfusion": {"minimum_version":"", "notes":"Member function is available in CF11+.", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-c-d/Day.html"},
+		"lucee": {"minimum_version":"", "notes":"Member function is available in Lucee4.5+.", "docs":"http://docs.lucee.org/reference/functions/day.html"},
 		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/function/day"},
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/function/day"}
 	},

--- a/data/en/dayofweek.json
+++ b/data/en/dayofweek.json
@@ -2,6 +2,7 @@
 	"name":"dayOfWeek",
 	"type":"function",
 	"syntax":"dayOfWeek(date)",
+	"member":"date.dayOfWeek()",
 	"returns":"Numeric",
 	"related":["Day", "DayOfWeekAsString", "DayOfYear", "DaysInMonth", "DaysInYear", "FirstDayOfMonth"],
 	"description":" Determines the day of the week, in a date. Returns the ordinal for the day of the week, as an integer in the range 1 (Sunday) to 7 (Saturday).",
@@ -10,8 +11,8 @@
 
 	],
 	"engines": {
-		"coldfusion": {"minimum_version":"", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-c-d/DayOfWeek.html"},
-		"lucee": {"minimum_version":"", "notes":"", "docs":"http://docs.lucee.org/reference/functions/dayofweek.html"},
+		"coldfusion": {"minimum_version":"", "notes":"Member function is available in CF11+.", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-c-d/DayOfWeek.html"},
+		"lucee": {"minimum_version":"", "notes":"Member function is available in Lucee4.5+.", "docs":"http://docs.lucee.org/reference/functions/dayofweek.html"},
 		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/function/dayofweek"},
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/function/dayofweek"}
 	},

--- a/data/en/dayofyear.json
+++ b/data/en/dayofyear.json
@@ -2,6 +2,7 @@
 	"name":"dayOfYear",
 	"type":"function",
 	"syntax":"dayOfYear(date)",
+	"member":"date.dayOfYear()",
 	"returns":"Numeric",
 	"related":["Day", "DayOfWeek", "DayOfWeekAsString", "DaysInMonth", "DaysInYear", "FirstDayOfMonth"],
 	"description":" Determines the day of the year, in a date.",
@@ -10,8 +11,8 @@
 
 	],
 	"engines": {
-		"coldfusion": {"minimum_version":"", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-c-d/DayOfYear.html"},
-		"lucee": {"minimum_version":"", "notes":"", "docs":"http://docs.lucee.org/reference/functions/dayofyear.html"},
+		"coldfusion": {"minimum_version":"", "notes":"Member function is available in CF11+.", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-c-d/DayOfYear.html"},
+		"lucee": {"minimum_version":"", "notes":"Member function is available in Lucee4.5+.", "docs":"http://docs.lucee.org/reference/functions/dayofyear.html"},
 		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/function/dayofyear"},
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/function/dayofyear"}
 	},

--- a/data/en/daysinmonth.json
+++ b/data/en/daysinmonth.json
@@ -2,6 +2,7 @@
 	"name":"daysInMonth",
 	"type":"function",
 	"syntax":"daysInMonth(date)",
+	"member":"date.daysInMonth()",
 	"returns":"Numeric",
 	"related":["Day", "DayOfWeek", "DayOfWeekAsString", "DayOfYear", "DaysInYear", "FirstDayOfMonth"],
 	"description":" Determines the number of days in a month.",
@@ -10,8 +11,8 @@
 
 	],
 	"engines": {
-		"coldfusion": {"minimum_version":"", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-c-d/DaysInMonth.html"},
-		"lucee": {"minimum_version":"", "notes":"", "docs":"http://docs.lucee.org/reference/functions/daysinmonth.html"},
+		"coldfusion": {"minimum_version":"", "notes":"Member function is available in CF11+.", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-c-d/DaysInMonth.html"},
+		"lucee": {"minimum_version":"", "notes":"Member function is available in Lucee4.5+.", "docs":"http://docs.lucee.org/reference/functions/daysinmonth.html"},
 		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/function/daysinmonth"},
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/function/daysinmonth"}
 	},

--- a/data/en/daysinyear.json
+++ b/data/en/daysinyear.json
@@ -2,6 +2,7 @@
 	"name":"daysInYear",
 	"type":"function",
 	"syntax":"daysInYear(date)",
+	"member":"date.daysInYear()",
 	"returns":"Numeric",
 	"related":["Day", "DayOfWeek", "DayOfWeekAsString", "DayOfYear", "DaysInMonth", "FirstDayOfMonth", "IsLeapYear"],
 	"description":" Determines the number of days in a year.",
@@ -10,8 +11,8 @@
 
 	],
 	"engines": {
-		"coldfusion": {"minimum_version":"", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-c-d/DaysInYear.html"},
-		"lucee": {"minimum_version":"", "notes":"", "docs":"http://docs.lucee.org/reference/functions/daysinyear.html"},
+		"coldfusion": {"minimum_version":"", "notes":"Member function is available in CF11+.", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-c-d/DaysInYear.html"},
+		"lucee": {"minimum_version":"", "notes":"Member function is available in Lucee4.5+.", "docs":"http://docs.lucee.org/reference/functions/daysinyear.html"},
 		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/function/daysinyear"},
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/function/daysinyear"}
 	},

--- a/data/en/firstdayofmonth.json
+++ b/data/en/firstdayofmonth.json
@@ -2,6 +2,7 @@
 	"name":"firstDayOfMonth",
 	"type":"function",
 	"syntax":"firstDayOfMonth(date)",
+	"member":"date.firstDayOfMonth()",
 	"returns":"Numeric",
 	"related":["Day", "DayOfWeek", "DayOfWeekAsString", "DayOfYear", "DaysInMonth", "DaysInYear"],
 	"description":" Determines the ordinal (day number, in the year) of the first\n day of the month in which a given date falls.",
@@ -10,8 +11,8 @@
 
 	],
 	"engines": {
-		"coldfusion": {"minimum_version":"", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-e-g/firstdayofmonth.html"},
-		"lucee": {"minimum_version":"", "notes":"", "docs":"http://docs.lucee.org/reference/functions/firstdayofmonth.html"},
+		"coldfusion": {"minimum_version":"", "notes":"Member function is available in CF11+.", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-e-g/firstdayofmonth.html"},
+		"lucee": {"minimum_version":"", "notes":"Member function is available in Lucee4.5+.", "docs":"http://docs.lucee.org/reference/functions/firstdayofmonth.html"},
 		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/function/firstdayofmonth"},
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/function/firstdayofmonth"}
 	},

--- a/data/en/hour.json
+++ b/data/en/hour.json
@@ -2,6 +2,7 @@
 	"name":"hour",
 	"type":"function",
 	"syntax":"hour(date)",
+	"member": "date.hour()",
 	"returns":"Numeric",
 	"related":["minute","second","month","quarter","week","year"],
 	"description":" Extracts the hour of the day from a date/time object.\n Ordinal value of the hour, in the range 0 - 23.",
@@ -9,8 +10,8 @@
 		{"name":"date","description":"","required":true,"default":"","type":"DateTime","values":["now()"]}
 	],
 	"engines": {
-		"coldfusion": {"minimum_version":"", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-h-im/hour.html"},
-		"lucee": {"minimum_version":"", "notes":"", "docs":"http://docs.lucee.org/reference/functions/hour.html"},
+		"coldfusion": {"minimum_version":"", "notes":"Member function is available in CF11+.", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-h-im/hour.html"},
+		"lucee": {"minimum_version":"", "notes":"Member function is available in Lucee4.5+.", "docs":"http://docs.lucee.org/reference/functions/hour.html"},
 		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/function/hour"},
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/function/hour"}
 	},

--- a/data/en/lsdateformat.json
+++ b/data/en/lsdateformat.json
@@ -2,6 +2,7 @@
 	"name":"LSDateFormat",
 	"type":"function",
 	"syntax":"LSDateFormat(date [, mask])",
+	"member":"date.lsDateFormat([mask])",
 	"returns":"String",
 	"related":[],
 	"description":" Formats the date part of a date/time value in a locale-specific\n format.\n [mask - quicky]\n d,dd,ddd,dddd: Day of month / week\n m,mm,mmm,mmmm: Month; y,yy,yyyy: Year; gg: Period/era string\n short / medium / long / full",
@@ -11,8 +12,8 @@
 
 	],
 	"engines": {
-		"coldfusion": {"minimum_version":"", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-l/lsdateformat.html"},
-		"lucee": {"minimum_version":"", "notes":"", "docs":"http://docs.lucee.org/reference/functions/lsdateformat.html"},
+		"coldfusion": {"minimum_version":"", "notes":"Member function is available in CF11+.", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-l/lsdateformat.html"},
+		"lucee": {"minimum_version":"", "notes":"Member function is available in Lucee4.5+.", "docs":"http://docs.lucee.org/reference/functions/lsdateformat.html"},
 		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/function/lsdateformat"},
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/function/lsdateformat"}
 	},

--- a/data/en/lstimeformat.json
+++ b/data/en/lstimeformat.json
@@ -2,6 +2,7 @@
 	"name":"LSTimeFormat",
 	"type":"function",
 	"syntax":"LSTimeFormat(time [, mask])",
+	"member":"time.lsTimeFormat([mask])",
 	"returns":"String",
 	"related":[],
 	"description":" Formats the time part of a date/time string into a string in a\n locale-specific format.\n [mask - quicky]\n h,hh,H,HH: Hours; m,mm: Minutes; s,ss: Seconds;\n l: Milliseconds; t: A or P; tt: AM or PM\n \"short\" = h:mm tt; \"medium\" = h:mm:ss tt",
@@ -11,8 +12,8 @@
 
 	],
 	"engines": {
-		"coldfusion": {"minimum_version":"", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-l/lstimeformat.html"},
-		"lucee": {"minimum_version":"", "notes":"", "docs":"http://docs.lucee.org/reference/functions/lstimeformat.html"},
+		"coldfusion": {"minimum_version":"", "notes":"Member function is available in CF2016+.", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-l/lstimeformat.html"},
+		"lucee": {"minimum_version":"", "notes":"Member function is not available.", "docs":"http://docs.lucee.org/reference/functions/lstimeformat.html"},
 		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/function/lstimeformat"},
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/function/lstimeformat"}
 	},

--- a/data/en/minute.json
+++ b/data/en/minute.json
@@ -2,6 +2,7 @@
 	"name":"minute",
 	"type":"function",
 	"syntax":"minute(date)",
+	"member":"date.minute()",
 	"returns":"Numeric",
 	"related":["hour","second","month","quarter","week","year"],
 	"description":" Extracts the minute value from a date/time object.",
@@ -10,8 +11,8 @@
 
 	],
 	"engines": {
-		"coldfusion": {"minimum_version":"", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-m-r/minute.html"},
-		"lucee": {"minimum_version":"", "notes":"", "docs":"http://docs.lucee.org/reference/functions/minute.html"},
+		"coldfusion": {"minimum_version":"", "notes":"Member function is available in CF11+.", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-m-r/minute.html"},
+		"lucee": {"minimum_version":"", "notes":"Member function is available in Lucee4.5+.", "docs":"http://docs.lucee.org/reference/functions/minute.html"},
 		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/function/minute"},
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/function/minute"}
 	},

--- a/data/en/month.json
+++ b/data/en/month.json
@@ -2,6 +2,7 @@
 	"name":"month",
 	"type":"function",
 	"syntax":"month(date)",
+	"member":"date.month()",
 	"returns":"Numeric",
 	"related":["hour","minute","second","quarter","week","year"],
 	"description":" Extracts the month value from a date/time object.",
@@ -10,8 +11,8 @@
 
 	],
 	"engines": {
-		"coldfusion": {"minimum_version":"", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-m-r/month.html"},
-		"lucee": {"minimum_version":"", "notes":"", "docs":"http://docs.lucee.org/reference/functions/month.html"},
+		"coldfusion": {"minimum_version":"", "notes":"Member function is available in CF11+.", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-m-r/month.html"},
+		"lucee": {"minimum_version":"", "notes":"Member function is available in Lucee4.5+.", "docs":"http://docs.lucee.org/reference/functions/month.html"},
 		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/function/month"},
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/function/month"}
 	},

--- a/data/en/quarter.json
+++ b/data/en/quarter.json
@@ -2,6 +2,7 @@
 	"name":"quarter",
 	"type":"function",
 	"syntax":"quarter(date)",
+	"member":"date.quarter()",
 	"returns":"Numeric",
 	"related":["hour","minute","second","month","week","year"],
 	"description":" Calculates the quarter of the year in which a date falls.",
@@ -10,8 +11,8 @@
 
 	],
 	"engines": {
-		"coldfusion": {"minimum_version":"", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-m-r/quarter.html"},
-		"lucee": {"minimum_version":"", "notes":"", "docs":"http://docs.lucee.org/reference/functions/quarter.html"},
+		"coldfusion": {"minimum_version":"", "notes":"Member function is available in CF11+.", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-m-r/quarter.html"},
+		"lucee": {"minimum_version":"", "notes":"Member function is available in Lucee4.5+.", "docs":"http://docs.lucee.org/reference/functions/quarter.html"},
 		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/function/quarter"},
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/function/quarter"}
 	},

--- a/data/en/second.json
+++ b/data/en/second.json
@@ -2,6 +2,7 @@
 	"name":"second",
 	"type":"function",
 	"syntax":"second(date)",
+	"member":"date.second()",
 	"returns":"Numeric",
 	"related":["hour","minute","month","quarter","week","year"],
 	"description":" Extracts the ordinal for the second from a date/time object.",
@@ -9,8 +10,8 @@
 		{"name":"date","description":"A date\/time object","required":true,"default":"","type":"DateTime","values":["now()"]}
 	],
 	"engines": {
-		"coldfusion": {"minimum_version":"", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-s/second.html"},
-		"lucee": {"minimum_version":"", "notes":"", "docs":"http://docs.lucee.org/reference/functions/second.html"},
+		"coldfusion": {"minimum_version":"", "notes":"Member function is available in CF11+.", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-s/second.html"},
+		"lucee": {"minimum_version":"", "notes":"Member function is available in Lucee4.5+.", "docs":"http://docs.lucee.org/reference/functions/second.html"},
 		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/function/second"},
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/function/second"}
 	},

--- a/data/en/timeformat.json
+++ b/data/en/timeformat.json
@@ -2,6 +2,7 @@
 	"name":"timeFormat",
 	"type":"function",
 	"syntax":"timeFormat(time [, mask])",
+	"member":"time.timeFormat([mask])",
 	"returns":"String",
 	"related":[],
 	"description":" Formats a time value using US English time formatting\n conventions. If no mask is specified, returns a time value\n using the hh:mm tt format. For international time formatting,\n see LSTimeFormat.\n [mask]\n h,hh,H,HH: Hours; m,mm: Minutes; s,ss: Seconds;\n l: Milliseconds; t: A or P; tt: AM or PM\n \"short\" = h:mm tt; \"medium\" = h:mm:ss tt",
@@ -11,8 +12,8 @@
 
 	],
 	"engines": {
-		"coldfusion": {"minimum_version":"", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-t-z/timeformat.html"},
-		"lucee": {"minimum_version":"", "notes":"", "docs":"http://docs.lucee.org/reference/functions/timeformat.html"},
+		"coldfusion": {"minimum_version":"", "notes":"Member function is available in CF11+.", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-t-z/timeformat.html"},
+		"lucee": {"minimum_version":"", "notes":"Member function is not available.", "docs":"http://docs.lucee.org/reference/functions/timeformat.html"},
 		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/function/timeformat"},
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/function/timeformat"}
 	},

--- a/data/en/week.json
+++ b/data/en/week.json
@@ -2,6 +2,7 @@
 	"name":"week",
 	"type":"function",
 	"syntax":"week(date)",
+	"member":"date.week()",
 	"returns":"Numeric",
 	"related":["hour","minute","second","month","quarter","year"],
 	"description":" From a date/time object, determines the week number within\n the year. An integer in the range 1-53; the ordinal of the\n week, within the year.",
@@ -9,8 +10,8 @@
 		{"name":"date","description":"A date\/time object in the range 100 AD-9999 AD.","required":true,"default":"","type":"DateTime","values":["now()"]}
 	],
 	"engines": {
-		"coldfusion": {"minimum_version":"", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-t-z/week.html"},
-		"lucee": {"minimum_version":"", "notes":"", "docs":"http://docs.lucee.org/reference/functions/week.html"},
+		"coldfusion": {"minimum_version":"", "notes":"Member function is available in CF11+.", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-t-z/week.html"},
+		"lucee": {"minimum_version":"", "notes":"Member function is available in Lucee4.5+.", "docs":"http://docs.lucee.org/reference/functions/week.html"},
 		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/function/week"},
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/function/week"}
 	},

--- a/data/en/year.json
+++ b/data/en/year.json
@@ -2,6 +2,7 @@
 	"name":"year",
 	"type":"function",
 	"syntax":"year(date)",
+	"member":"date.year()",
 	"returns":"Numeric",
 	"related":["hour","minute","second","month","quarter","week"],
 	"description":" From a date/time object, gets the year value.",
@@ -9,8 +10,8 @@
 		{"name":"date","description":"","required":true,"default":"","type":"DateTime","values":["now()"]}
 	],
 	"engines": {
-		"coldfusion": {"minimum_version":"", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-t-z/year.html"},
-		"lucee": {"minimum_version":"", "notes":"", "docs":"http://docs.lucee.org/reference/functions/year.html"},
+		"coldfusion": {"minimum_version":"", "notes":"Member function is available in CF11+.", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-t-z/year.html"},
+		"lucee": {"minimum_version":"", "notes":"Member function is available in Lucee4.5+.", "docs":"http://docs.lucee.org/reference/functions/year.html"},
 		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/function/year"},
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/function/year"}
 	},


### PR DESCRIPTION
@pfreitag: Could you review this? I put information about when the member functions were added in the notes for the engines. I am not sure you want it there, but I wasn't sure if there was a better place to put it.

There are two places where I added additional notes:
- `datepart.json`: the syntax differs between CF and Lucee - I added that to the notes under the Lucee engine. 
- `datediff.json`: here it seems that CF and Lucee behave differently with how they diff the dates. I added a note about it to the Lucee engine, as well as an example that can be run that illustrates the difference.

CF2016 also has the `.setSecond()`, `.setMinute()`, etc. member functions, but since there are no corresponding BIFs I wasn't sure what to do with them.

Let me know if anything needs to be changed.