### PR TITLE
Added create and delete examples for cfschedule

### DIFF
--- a/data/en/cfschedule.json
+++ b/data/en/cfschedule.json
@@ -38,5 +38,22 @@
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/tag/cfschedule"}
 	},
 	"links": [
-	]
+	],
+  "examples": [
+    {
+      "title": "Create or update a task",
+      "description": "Tell Coldfusion to run 'importData.cfm' daily at 7AM",
+      "code": "<cfschedule\r\n action=\"update\"\r\n task=\"importMyCSVFileToDB\"\r\n operation=\"HTTPRequest\"\r\n startDate=\"5/12/2016\"\r\n startTime=\"7:00 AM\"\r\n url=\"http://www.mydomain.com/scheduled/importData.cfm\"\r\n interval=\"daily\" />",
+      "result": "",
+      "runnable":false
+    },
+    {
+      "title": "Delete a scheduled task",
+      "description": "Delete the task 'importMyCSVFileToDB' from the list of Coldfusion scheduled jobs",
+      "code": "<cfschedule\r\n action=\"delete\"\r\n task=\"importMyCSVFileToDB\" />",
+      "result": "",
+      "runnable":false
+    }
+
+  ]
 }


### PR DESCRIPTION
They're somewhat wimpy little examples, but they'd sure be helpful next time!

I made sure to set `runnable` to `false` for both examples. I'm absolutely sure that `trycf.com` won't support any scheduling CFML.

![cfdocs-cfschedule-brief-examples](https://cloud.githubusercontent.com/assets/8106227/19027612/c47b8394-88ff-11e6-9cd5-b97d40a2bebd.png)
