### PR TITLE
Missing keysize argument for generateSecretKey.

### DIFF
--- a/data/en/generatesecretkey.json
+++ b/data/en/generatesecretkey.json
@@ -1,12 +1,13 @@
 {
 	"name":"generateSecretKey",
 	"type":"function",
-	"syntax":"generateSecretKey([algorithm])",
+	"syntax":"generateSecretKey([algorithm] [,keysize])",
 	"returns":"String",
 	"related":["encrypt","decrypt"],
 	"description":"Generates a secure random key value for use in the encrypt and decrypt functions.",
 	"params": [
-		{"name":"algorithm","description":"","required":false,"default":"","type":"String","values":["CFMX_COMPAT","AES","BLOWFISH","DES","DESEDE"]}
+		{"name":"algorithm","description":"","required":false,"default":"","type":"String","values":["CFMX_COMPAT","AES","BLOWFISH","DES","DESEDE"]},
+		{"name":"keysize","description":"Number of bits requested in the key for the specified algorithm (when allowed by JDK).","required":false,"default":"128","type":"Numeric","values":["128", "256"]}
 
 	],
 	"engines": {


### PR DESCRIPTION
Added information for the keysize argument of this function - checked that it definitely exists for Lucee 4.5 and 5, using trycf.com as well as ACF. Although the coldfusion docs say that this was added for ACF8+ (can we add argument-specific version info to the engines section?).