### PR TITLE
Additional details and examples for cacheget and cacheput

### DIFF
--- a/data/en/cacheget.json
+++ b/data/en/cacheget.json
@@ -7,7 +7,8 @@
 	"description":" Gets an object that is stored in the cache.",
 	"params": [
 		{"name":"id","description":"The ID value assigned to the cache object when it was created","required":true,"default":"","type":"String","values":[]},
-		{"name":"region","description":"CF10+ The name of the cache region where the object was stored","required":false,"default":"","type":"String","values":[]}
+		{"name":"region","description":"CF10+ The name of the cache region where the object was stored. Applies only to ACF.","required":false,"default":"","type":"String","values":[]},
+		{"name":"cacheName","description":"Lucee4.5+ The name of the cache where the object was stored. Applies only to Lucee.","required":false,"default":"","type":"String","values":[]}
 	],
 	"engines": {
 		"coldfusion": {"minimum_version":"9", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-c-d/CacheGet.html"},
@@ -21,9 +22,17 @@
 	"examples": [
 		{
 			"title":"Simple Example",
-			"code":"cowSays = cacheGet(\"cow\");\nif (isNull(cowSays)) {\n    cachePut(\"cow\", \"moo\");\n    cowSays=\"moo\";\n}\nwriteOutput( \"The cow says \" & cowSays );",
 			"description":"Puts an element in the cache and then retreives it.",
-			"result":"The cow says moo"
+			"code":"cowSays = cacheGet( \"cow\" );\nif ( isNull( cowSays ) ) {\n    cowSays = \"moo\";\n    cachePut( \"cow\", cowSays, createTimeSpan( 0, 0, 30, 0 ), createTimeSpan( 0, 0, 15, 0 ) );\n}\nwriteOutput( \"The cow says \" & cowSays );",
+			"result":"The cow says moo",
+			"runnable":true
+		},
+		{
+			"title":"Script Syntax - Named Cache",
+			"description":"Puts an element in a named cache and then retreives it. CF10+ Lucee4.5+",
+			"result":"The cow says moo",
+			"code":"cowSays = cacheGet( \"cow\", \"region_cacheName\" );\nif ( isNull( cowSays ) ) {\n    cowSays = \"moo\";\n    cachePut( \"cow\", cowSays, createTimeSpan( 0, 0, 30, 0 ), createTimeSpan( 0, 0, 15, 0 ), \"region_cacheName\" );\n}\nwriteOutput( \"The cow says \" & cowSays );",
+			"runnable":false
 		}
 	]
 

--- a/data/en/cacheput.json
+++ b/data/en/cacheput.json
@@ -9,7 +9,9 @@
 		{"name":"id","description":"Unique identifier for the cached value","required":true,"default":"","type":"String","values":[]},
 		{"name":"value","description":"The value to cache","required":true,"default":"","type":"String","values":[]},
 		{"name":"timespan","description":"The interval until the object is flushed from the cache, as a decimal number of days. One way to set the value is to use the return value from the CreateTimeSpan function. The default is to not time out the object.","required":false,"default":"","type":"DateTime","values":[]},
-		{"name":"idleTime","description":"A decimal number of days after which the object is flushed from the cache if it is not accessed during that time. One way to set the value is to use the return value from the CreateTimeSpan function.","required":false,"default":"","type":"DateTime","values":[]}
+		{"name":"idleTime","description":"A decimal number of days after which the object is flushed from the cache if it is not accessed during that time. One way to set the value is to use the return value from the CreateTimeSpan function.","required":false,"default":"","type":"DateTime","values":[]},
+		{"name":"region","description":"CF10+ Specifies the cache region where you can place the cache object. Applies only to ACF.","required":false,"default":"","type":"String","values":[]},
+		{"name":"cacheName","description":"Lucee4.5+ Definition of the cache used by name. Applies only to Lucee.","required":false,"default":"","type":"String","values":[]}
 
 	],
 	"engines": {
@@ -28,6 +30,20 @@
 			"code": "<cfset cachedData = cacheGet(\"wt-6-cache\")> \r\n <!--- If the data is not cached, create it and do a cache put. ---> \r\n <cfif isNull(cachedData)> \r\n     Cache doesn't exist, so create it.<br /> \r\n     <cfset sleep(1000)> \r\n     <cfset cachedData = \"This date/time IS cached: #now()#<br />\"> \r\n     <cfoutput>#cachedData#</cfoutput> \r\n     <cfset cachePut(\"wt-6-cache\", cachedData, createTimespan(0,0,0,10))> \r\n </cfif>  ",
 			"result": "",
             "runnable":false
+		},
+		{
+			"title":"Script Syntax",
+			"description":"I place data into the default cache.",
+			"code":"<cfscript>\r\n// generate some data to cache\r\ndata = { bar = 'foo', foo = 'bar' };\r\n\r\n// add the data to a named cache\r\ncachePut( 'cached_object_name_or_id', data, createTimeSpan( 0, 0, 30, 0 ), createTimeSpan( 0, 0, 15, 0 ) );\r\n</cfscript>",
+			"result":"",
+			"runnable":false
+		},
+		{
+			"title":"Script Syntax - Named Cache",
+			"description":"I place data into a named cache. CF10+ Lucee4.5+",
+			"code":"<cfscript>\r\n// generate some data to cache\r\ndata = { bar = 'foo', foo = 'bar' };\r\n\r\n// add the data to a named cache\r\ncachePut( 'cached_object_name_or_id', data, createTimeSpan( 0, 0, 30, 0 ), createTimeSpan( 0, 0, 15, 0 ), 'region_cacheName' );\r\n</cfscript>",
+			"result":"",
+			"runnable":false
 		}
 	]
 


### PR DESCRIPTION
Expanded on the argument references to include Lucee arguments, denoting
differences
Added CF10+ to cachePut region argument
Added additional examples for script syntax (cacheput) and named caches