### PR TITLE
Improvements in file upload example

### DIFF
--- a/data/en/fileupload.json
+++ b/data/en/fileupload.json
@@ -79,7 +79,7 @@
     {
       "title": "Upload form with strict check on MIME type",
       "description": "",
-      "code": "<form method=\"post\" enctype=\"multipart\/form-data\">\r\n  <input type=\"file\" name=\"fileInput\">\r\n  <button type=\"submit\">Upload<\/button>\r\n<\/form>\r\n\r\n<cfscript>\r\n  if( structKeyExists( form, \"fileInput\" )) {\r\n    try {\r\n      uploadedFile = fileUpload( \".\/\", \"fileInput\", \"image\/jpeg,image\/pjpeg\", \"MakeUnique\" );\r\n\r\n      \/\/ do stuff with uploadedFile...\r\n    } catch ( coldfusion.tagext.io.FileUtils$InvalidUploadTypeException e ) {\r\n      writeOutput( \"This upload form only accepts JPEG files.\" );\r\n    }\r\n  }\r\n<\/cfscript>",
+      "code": "<form method=\"post\" enctype=\"multipart/form-data\">\r\n  <input type=\"file\" name=\"fileInput\">\r\n  <button type=\"submit\">Upload</button>\r\n</form>\r\n\r\n<cfscript>\r\n  if( structKeyExists( form, \"fileInput\" )) {\r\n    try {\r\n      uploadedFile = fileUpload( getTempDirectory(), \"fileInput\", \"image/jpeg,image/pjpeg\", \"MakeUnique\" );\r\n      // check the file extension of the uploaded file; mime types can be spoofed\r\n      if (not listFindNoCase(\"jpg,jpeg\", cffile.serverFileExt)) {\r\n      throw(\"The uploaded file is not of type JPG.\");\r\n      }\r\n      // do stuff with uploadedFile...\r\n    } catch ( coldfusion.tagext.io.FileUtils$InvalidUploadTypeException e ) {\r\n      writeOutput( \"This upload form only accepts JPEG files.\" );\r\n    }\r\n    catch (any e) {\r\n    writeOutput( \"An error occurred while uploading your file: #e.message#\" );\r\n    }\r\n  }\r\n</cfscript>",
       "result": "",
       "runnable": false
     }


### PR DESCRIPTION
First, never upload directly to a web accessible directory. Second, always check the incoming file extension. Checking on mime type alone does not do it, this can be easily spoofed.