### PR TITLE
Add cfloop to "see also" section of cfoutput

### DIFF
--- a/data/en/cfoutput.json
+++ b/data/en/cfoutput.json
@@ -4,7 +4,7 @@
 	"syntax":"<cfoutput>",
 	"script":"writeOutput()",
 	"returns":"",
-	"related":["writeOutput","encodeForHTML","encodeForHTMLAttribute"],
+	"related":["cfloop","writeOutput","encodeForHTML","encodeForHTMLAttribute"],
 	"description":"Displays output that can contain the results of processing CFML variables and functions. You can use the `query` attribute to loop over the result set of a database query.",
 	"params": [
 		{"name":"query","description":"Name of cfquery from which to draw data for output section.","required":false,"default":"","type":"query","values":[]},


### PR DESCRIPTION
Because `cfloop(query="x" group="y")` is the cfscript version of `<cfoutput query="x" group="y">`.