### PR TITLE
Encode brackets in <p> in paragraphFormat docs

### DIFF
--- a/data/en/paragraphformat.json
+++ b/data/en/paragraphformat.json
@@ -4,7 +4,7 @@
 	"syntax":"paragraphFormat(String)",
 	"returns":"String",
 	"related":[],
-	"description":" Replaces characters in a string:\n * Single newline characters (CR/LF sequences) with spaces\n * Double newline characters with HTML paragraph tags (<p>)",
+	"description":" Replaces characters in a string:\n * Single newline characters (CR/LF sequences) with spaces\n * Double newline characters with HTML paragraph tags (<code>&lt;p&gt;</code>)",
 	"params": [
 		{"name":"String","description":"","required":true,"default":"","type":"String","values":[]}
 


### PR DESCRIPTION
The description on https://cfdocs.org/paragraphformat outputs the `<p>` in the example verbatim onto the page, which leads to an empty pair of parens.

I encoded the angle brackets.