### PR TITLE
Add entities to description of the htmlCodeFormat function

### DIFF
--- a/data/en/htmlcodeformat.json
+++ b/data/en/htmlcodeformat.json
@@ -4,7 +4,7 @@
 	"syntax":"HTMLCodeFormat(String [, version])",
 	"returns":"String",
 	"related":[],
-	"description":" Replaces special characters in a string with their HTML-escaped\n equivalents and inserts <pre> and </pre> tags at the beginning\n and end of the string.\n [version]\n HTML version to use. currently ignored.\n -1: The latest implementation of HTML\n 2.0: HTML 2.0 (Default)\n 3.2: HTML 3.2",
+	"description":" Replaces special characters in a string with their HTML-escaped\n equivalents and inserts &ltpre&gt; and &lt/pre&gt tags at the beginning\n and end of the string.\n [version]\n HTML version to use. currently ignored.\n -1: The latest implementation of HTML\n 2.0: HTML 2.0 (Default)\n 3.2: HTML 3.2",
 	"params": [
 		{"name":"String","description":"","required":true,"default":"","type":"String","values":[]},
 		{"name":"version","description":"","required":false,"default":"","type":"Numeric","values":[-1,2.0,3.2]}


### PR DESCRIPTION
I switched these out for entities, so that the block doesn't look like this:

<img src=https://user-images.githubusercontent.com/464441/28138594-0101a5c8-6717-11e7-8bc2-1fcd13a1dd60.png width=613>
