### PR TITLE
Clarified usage of 'startrow' and 'maxrows' attributes and added an example for their usage

### DIFF
--- a/data/en/cfoutput.json
+++ b/data/en/cfoutput.json
@@ -10,8 +10,8 @@
 		{"name":"query","description":"Name of cfquery from which to draw data for output section.","required":false,"default":"","type":"query","values":[]},
 		{"name":"group","description":"Query column to use to group sets of records. Eliminates\n adjacent duplicate rows when data is sorted. Use if you\n retrieved a record set ordered on one or more a query\n columns. For example, if a record set is ordered on\n \"Customer_ID\" in the cfquery tag, you can group the output\n on \"Customer_ID.\"","required":false,"default":"","type":"String","values":[]},
 		{"name":"groupcasesensitive","description":"Whether to consider the case in grouping rows.","required":false,"default":"","type":"boolean","values":[true,false]},
-		{"name":"startrow","description":"Row from which to start output.","required":false,"default":"","type":"Numeric","values":[]},
-		{"name":"maxrows","description":"Maximum number of rows to display.","required":false,"default":"","type":"Numeric","values":[]},
+		{"name":"startrow","description":"Row from which to start output. Only considered when the query attribute is set.\nThis attribute in combination with maxrows can be used to create some paging.","required":false,"default":"","type":"Numeric","values":[]},
+		{"name":"maxrows","description":"Maximum number of rows to display. Only considered when the query attribute is set.","required":false,"default":"","type":"Numeric","values":[]},
 		{"name":"encodefor","description":"CF2016+ Lucee5.1+ When set applies an encoder to all variables to prevent XSS. For example if you specify `html` each variable will be wrapped by a call to the `encodeForHTML` function.","required":false,"default":"","type":"string","values":["html","htmlattribute","javascript","css","xml","xmlattribute","url","xpath","ldap","dn"]}
 
 	],
@@ -35,6 +35,12 @@
 	            "title": "Loop over a query",
 	            "description": "Loops over each row of the query specified and outputs the result.",
 	            "code": "<cfoutput query=\"news\">\n    <h2>#encodeForHTML(news.headline)#</h2>\n    <p>#encodeForHTML(news.byline)#</p>\n</cfoutput>",
+	            "result": ""
+	    },
+	    {
+	            "title": "Loop over a range of rows of a query",
+	            "description": "Loops over 10 rows of the query specified starting from row 5 and outputs the result.",
+	            "code": "<cfoutput query=\"news\" startrow=\"5\" maxrows=\"10\">\n    <h2>#encodeForHTML(news.headline)#</h2>\n    <p>#encodeForHTML(news.byline)#</p>\n</cfoutput>",
 	            "result": ""
 	    },
 	    {


### PR DESCRIPTION
This extends the descriptions of the `startrow` and `maxrows` attributes and adds and example related to them to make it clear how they are used.