### PR TITLE
add tag and script examples for cftimer

### DIFF
--- a/data/en/cftimer.json
+++ b/data/en/cftimer.json
@@ -18,6 +18,21 @@
 	},
 	"links": [
 
+	],
+	"examples": [
+		{
+			"title": "Tag version",
+			"description": "",
+			"code": "<cftimer label=\"Nap time\" type=\"inline\">\nBegin some long running process ...\n<cfset sleep(2000)>\ndone.\n</cftimer>",
+			"result": "The time elapsed while executing the code inside the <cftimer> block should be displayed inline.",
+			"runnable": false
+		},
+		{
+			"title": "Script version",
+			"description": "",
+			"code": "cftimer(label = \"Nap time\", type=\"outline\"){\nwriteoutput(\"Begin some long running process ... \");\nsleep(2000);\nwriteoutput(\"done.\");\n}",
+			"result": "The time elapsed while executing the code inside the cftimer block should be displayed in the output with an outline around any output generated within the cftimer call..",
+			"runnable": false
+		}
 	]
-
 }


### PR DESCRIPTION
I wasn't able to get these examples to run properly on the Adobe servers in the pop up runner so I set the runnable property to false to avoid confusion. Let me know if I'm missing something there.

Thanks!