### PR TITLE
[minor] Deprecated componentInfo()

### DIFF
--- a/data/en/componentinfo.json
+++ b/data/en/componentinfo.json
@@ -9,7 +9,7 @@
 		{"name": "component", "description": "", "required": true, "default": "", "type": "component", "values": []}
 	],
 	"engines": {
-		"lucee": {"minimum_version": "", "notes": "", "docs": "http://docs.lucee.org/reference/functions/componentinfo.html"}
+		"lucee": {"minimum_version": "", deprecated:"4.5", "notes": "In Lucee4.5+ `componentInfo()` is deprecated in favor of `getMetaData()`", "docs": "http://docs.lucee.org/reference/functions/componentinfo.html"}
 	},
 	"examples": [],
 	"links": []

--- a/data/en/componentinfo.json
+++ b/data/en/componentinfo.json
@@ -9,7 +9,7 @@
 		{"name": "component", "description": "", "required": true, "default": "", "type": "component", "values": []}
 	],
 	"engines": {
-		"lucee": {"minimum_version": "", deprecated:"4.5", "notes": "In Lucee4.5+ `componentInfo()` is deprecated in favor of `getMetaData()`", "docs": "http://docs.lucee.org/reference/functions/componentinfo.html"}
+		"lucee": {"minimum_version": "", "deprecated":"4.5", "notes": "In Lucee4.5+ `componentInfo()` is deprecated in favor of `getMetaData()`", "docs": "http://docs.lucee.org/reference/functions/componentinfo.html"}
 	},
 	"examples": [],
 	"links": []


### PR DESCRIPTION
According to docs: http://docs.lucee.org/reference/functions/componentinfo.html