### PR TITLE
Added note to use cacheIdExists instead

### DIFF
--- a/data/en/cachekeyexists.json
+++ b/data/en/cachekeyexists.json
@@ -10,7 +10,7 @@
 		{"name": "cacheName", "description": "Definition of the cache used by name, when not set the \"default Object Cache\" defined in Lucee Administrator is used instead.", "required": false, "default": "", "type": "string", "values": []}
 	],
 	"engines": {
-		"lucee": {"minimum_version": "", "deprecated": "4.5", "notes": "", "docs": "http://docs.lucee.org/reference/functions/cachekeyexists.html"}
+		"lucee": {"minimum_version": "", "deprecated": "4.5", "notes": "Use CacheIdExists instead", "docs": "http://docs.lucee.org/reference/functions/cachekeyexists.html"}
 	},
 	"examples": [],
 	"links": []


### PR DESCRIPTION
Added note to use CacheIdExists instead as this function is deprecated. This got lost in my previous update to this page.