### PR TITLE
Added basic function description to getfunctionkeywords().

### DIFF
--- a/data/en/getfunctionkeywords.json
+++ b/data/en/getfunctionkeywords.json
@@ -4,7 +4,7 @@
 	"syntax": "getFunctionKeywords()",
 	"returns": "array",
 	"related": [],
-	"description": "",
+	"description": "Returns all keywords defined with all functions.",
 	"params": [],
 	"engines": {
 		"lucee": {"minimum_version": "", "notes": "", "docs": "http://docs.lucee.org/reference/functions/getfunctionkeywords.html"}


### PR DESCRIPTION
I happened to notice this `getfunctionkeywords()` function is missing a description. (To say the least.) I updated this with the description from the Lucee docs.

http://docs.lucee.org/reference/functions/getfunctionkeywords.html