### PR TITLE
Added compatibilty note for script version of tag

### DIFF
--- a/data/en/cfheader.json
+++ b/data/en/cfheader.json
@@ -13,7 +13,7 @@
 
 	],
 	"engines": {
-		"coldfusion": {"minimum_version":"", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-tags/tags-g-h/cfheader.html"},
+		"coldfusion": {"minimum_version":"", "notes":"Script-based cfheader() added in CF11", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-tags/tags-g-h/cfheader.html"},
 		"lucee": {"minimum_version":"", "notes":"", "docs":"http://docs.lucee.org/reference/tags/header.html"},
 		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/tag/cfheader"},
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/tag/cfheader"}

--- a/data/en/cfheader.json
+++ b/data/en/cfheader.json
@@ -13,7 +13,7 @@
 
 	],
 	"engines": {
-		"coldfusion": {"minimum_version":"", "notes":"Script-based cfheader() added in CF11", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-tags/tags-g-h/cfheader.html"},
+		"coldfusion": {"minimum_version":"", "notes":"CF11+ Added script-based cfheader()", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-tags/tags-g-h/cfheader.html"},
 		"lucee": {"minimum_version":"", "notes":"", "docs":"http://docs.lucee.org/reference/tags/header.html"},
 		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/tag/cfheader"},
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/tag/cfheader"}


### PR DESCRIPTION
Calling cfheader(), the script-based version of this tag, is only available on CF11+. CF10 will trigger a 500 "Variable CFHEADER is undefined" error.