### PR TITLE
Update datediff.json

### DIFF
--- a/data/en/datediff.json
+++ b/data/en/datediff.json
@@ -7,7 +7,7 @@
 	"related":["dateadd","dateformat"],
 	"description":"Determines the integer number of datepart units by which date1 is less than date2.",
 	"params": [
-		{"name":"datepart","description":"yyyy: Year\n q: Quarter\n m: Month\n y: Day of year\n d: Day\n w: Weekday\n ww: Week\n h: Hour\n n: Minute\n s: Second\n","required":true,"default":"","type":"string","values":["yyyy","q","m","y","d","w","ww","h","n","s"]},
+		{"name":"datepart","description":"yyyy: Year\n q: Quarter\n m: Month\n y: Day of year\n d: Day\n w: Week\n ww: Week\n h: Hour\n n: Minute\n s: Second\n","required":true,"default":"","type":"string","values":["yyyy","q","m","y","d","w","ww","h","n","s"]},
 		{"name":"date1","description":"","required":true,"default":"","type":"date","values":[]},
 		{"name":"date2","description":"","required":true,"default":"","type":"date","values":[]}
 	],


### PR DESCRIPTION
Both Lucee and ACF use "w" and "ww" for weeks. There is no weekday option.

As per ACF docs:

String that specifies the units in which to count; for example yyyy requests a date difference in whole years.

yyyy: Years
q: Quarters
m: Months
y: Days of year (same as d)
d: Days
w: Weeks
ww: Weeks
h: Hours
n: Minutes
s: Seconds

cfdocs currently has:

w: Weekday