### PR TITLE
Fixed misspelling in OrmEvictQueries.json

### DIFF
--- a/data/en/ormevictqueries.json
+++ b/data/en/ormevictqueries.json
@@ -4,7 +4,7 @@
 	"syntax":"ormEvictQueries([cacheName])",
 	"returns":"void",
 	"related":[],
-	"description":"This will remove all the queries from the named query cache. \nIf name is not specified, all quiries from default cache will be removed.\normEvictQueries([cacheName])",
+	"description":"This will remove all the queries from the named query cache. \nIf name is not specified, all queries from default cache will be removed.\normEvictQueries([cacheName])",
 	"params": [
 		{"name":"cacheName","description":"No Help Available","required":false,"default":"","type":"string","values":[]}
 


### PR DESCRIPTION
Changed "quiries" to "queries".

https://cfdocs.org/ormevictqueries