### PR TITLE
Cleanup and make proper links for accessing from cfdocs.org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,10 +2,10 @@
 
 ### I want to help but I'm not sure what needs to be done
 
-1) Look at our [list of Tags / Functions Missing Descriptions](https://cfdocs.org/reports/missing-descriptions.cfm) and add a description.
-2) Look at our [list of Tags / Functions without Examples](https://cfdocs.org/reports/missing-examples.cfm) and add some examples. You can use [this utility](https://cfdocs.org/utilities/json/) to format the examples into the correct JSON format.
-3) Look at our [list of Tags / Functions without Related Links](https://cfdocs.org/reports/missing-related.cfm) and add a link to a related blog entry or article.
-4) Look at our [GitHub Open Issues](https://github.com/foundeo/cfdocs/issues) and fix something.
+1. Look at our [list of Tags / Functions Missing Descriptions](https://cfdocs.org/reports/missing-descriptions.cfm) and add a description.
+2. Look at our [list of Tags / Functions without Examples](https://cfdocs.org/reports/missing-examples.cfm) and add some examples. You can use [this utility](https://cfdocs.org/utilities/json/) to format the examples into the correct JSON format.
+3. Look at our [list of Tags / Functions without Related Links](https://cfdocs.org/reports/missing-related.cfm) and add a link to a related blog entry or article.
+4. Look at our [GitHub Open Issues](https://github.com/foundeo/cfdocs/issues) and fix something.
 
 ### Where can I find documentation about the JSON file format used?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,11 +5,11 @@
 1) Look at our [list of Tags / Functions Missing Descriptions](https://cfdocs.org/reports/missing-descriptions.cfm) and add a description.
 2) Look at our [list of Tags / Functions without Examples](https://cfdocs.org/reports/missing-examples.cfm) and add some examples. You can use [this utility](https://cfdocs.org/utilities/json/) to format the examples into the correct JSON format.
 3) Look at our [list of Tags / Functions without Related Links](https://cfdocs.org/reports/missing-related.cfm) and add a link to a related blog entry or article.
-4) Look at our [Github Open Issues](https://github.com/foundeo/cfdocs/issues) and fix something.
+4) Look at our [GitHub Open Issues](https://github.com/foundeo/cfdocs/issues) and fix something.
 
 ### Where can I find documentation about the JSON file format used?
 
-The main README has that documented: https://github.com/foundeo/cfdocs#json-file-documentation
+It's documented in the [main README](/foundeo/cfdocs#json-file-documentation).
 
 ### What version of CF should the cfdocs CFML code work on?
 
@@ -27,7 +27,7 @@ Use `true`/`false`
 
 ### How are my contributions licensed?
 
-Please see the [LICENSE](LICENSE) file.
+Please see the [LICENSE](/foundeo/cfdocs/LICENSE) file.
 
 ### Can I copy code examples from other sources?
 
@@ -40,4 +40,3 @@ do not show up right away. Most pages are cached for 24 hours.
 
 If you are not showing up on the leaderboard after 24 hours you might need to 
 try this: http://contribution-checker.herokuapp.com/
-


### PR DESCRIPTION
Example: https://cfdocs.org/how-to-contribute

"LICENSE" links to https://cfdocs.org/LICENSE