### PR TITLE
Various changes in arrayEach()

### DIFF
--- a/data/en/arrayeach.json
+++ b/data/en/arrayeach.json
@@ -9,9 +9,8 @@
 	"params": [
 		{"name":"array","description":"","required":true,"default":"","type":"array","values":[]},
 		{"name":"closure","description":"function / closure with the signature: any function (any item, [numeric index], [array array]) - will be executed once per item in the array","required":true,"default":"","type":"function","values":[]},
-		{"name":"parallel","description":"Railo only option, true or false if the items can be executed in parallel","required":false,"default":"false","type":"boolean","values":[true, false]},
-		{"name":"maxThreads","description":"Railo only option, the number of threads to use when parallel = true","required":false,"default":"20","type":"boolean","values":[]}
-
+		{"name":"parallel","description":"Lucee4.5+ Specifies whether the items can be executed in parallel","required":false,"default":"false","type":"boolean","values":[]},
+		{"name":"maxThreads","description":"Lucee4.5+ The number of threads to use when parallel = true","required":false,"default":"20","type":"numeric","values":[]}
 	],
 	"engines": {
 		"coldfusion": {"minimum_version":"10", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-a-b/arrayeach.html"},
@@ -32,15 +31,14 @@
 		{
 			"title": "Simple Example",
 			"description": "",
-			"code": "letters = [\"a\",\"b\",\"c\",\"d\"]; \r\narrayEach(letters, function(element,index) \r\n {\r\n    writeOutput(\"#index#:#element#;\");\r\n});",
+			"code": "letters = [\"a\",\"b\",\"c\",\"d\"]; \r\narrayEach(letters, function(element,index) {\r\n    writeOutput(\"#index#:#element#;\");\r\n});",
 			"result": "1:a;2:b;3:c;4:d;"
 		},
 		{
 			"title": "Member Function Example",
-			"description": "Array Loop -- array.Each()",
+			"description": "",
 			"code": "a = [\"a\",\"b\",\"c\"];\r\na.each(function(element,index,array){\r\n    writeOutput(\"#index#:#element#;\"); \r\n});",
 			"result": "1:a;2:b;3:c;"
 		}
 	]
-
 }


### PR DESCRIPTION
- Add engine labels instead of "{engine} only" string
- Simplified boolean parameter description
- Boolean parameter need no explicit values
- Correct param type of `maxThreads` must be numeric (defaults to a number)
- Cleanup code of example 1
- Remove unnecessary description of example 2