### PR TITLE
Added example to structFind() and optional 'defaultValue' parameter

### DIFF
--- a/data/en/structfind.json
+++ b/data/en/structfind.json
@@ -1,13 +1,14 @@
 {
 	"name":"structFind",
 	"type":"function",
-	"syntax":"structFind(structure, key)",
+	"syntax":"structFind(structure, key [, defaultValue ])",
 	"returns":"any",
-	"related":[],
-	"description":" Determines the value associated with a key in a structure.",
+	"related":["structFindKey", "structFindValue"],
+	"description":"Determines the value associated with a key in a structure.",
 	"params": [
-		{"name":"structure","description":"Structure that contains the value to return","required":true,"default":"","type":"struct","values":[]},
-		{"name":"key","description":"Key whose value to return","required":true,"default":"","type":"string","values":[]}
+		{"name": "structure", "description": "Structure that contains the value to return", "required": true, "default": "", "type": "struct", "values": []},
+		{"name": "key", "description": "Key whose value to return", "required": true, "default": "", "type": "string", "values": []},
+		{"name": "defaultValue", "description": "Default value which will be returned if the key does not exist or if null was found. Currently only supported by Lucee. See http://docs.lucee.org/reference/functions/structfind.html#argument-defaultValue", "required": false, "default": "", "type": "any"}
 
 	],
 	"engines": {
@@ -16,6 +17,17 @@
 		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/function/structfind"},
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/function/structfind"}
 	},
+
+	"examples": [
+		{
+			"title": "Simple example",
+			"description": "Searches through a structure by a given key and outputs the related value",
+			"code": "countries = {\r\n    \"USA\"=\"Washington D.C.\",\r\n    \"Germany\"=\"Berlin\",\r\n    \"Japan\"=\"Tokio\"\r\n};\r\nwriteOutput(structFind(countries, \"Germany\"));",
+			"result": "Berlin",
+			"runnable": true
+		}
+	],
+
 	"links": [
 
 	]

--- a/data/en/structfind.json
+++ b/data/en/structfind.json
@@ -2,6 +2,7 @@
 	"name":"structFind",
 	"type":"function",
 	"syntax":"structFind(structure, key [, defaultValue ])",
+	"member": "struct.find(key [, defaultValue ])",
 	"returns":"any",
 	"related":["structFindKey", "structFindValue"],
 	"description":"Determines the value associated with a key in a structure.",

--- a/data/en/structfind.json
+++ b/data/en/structfind.json
@@ -8,7 +8,7 @@
 	"params": [
 		{"name": "structure", "description": "Structure that contains the value to return", "required": true, "default": "", "type": "struct", "values": []},
 		{"name": "key", "description": "Key whose value to return", "required": true, "default": "", "type": "string", "values": []},
-		{"name": "defaultValue", "description": "Default value which will be returned if the key does not exist or if null was found. Currently only supported by Lucee. See http://docs.lucee.org/reference/functions/structfind.html#argument-defaultValue", "required": false, "default": "", "type": "any"}
+		{"name": "defaultValue", "description": "Lucee4.5+ Default value which will be returned if the key does not exist or if null was found. Currently only supported by Lucee. See http://docs.lucee.org/reference/functions/structfind.html#argument-defaultValue", "required": false, "default": "", "type": "any"}
 
 	],
 	"engines": {


### PR DESCRIPTION
The `defaultValue` parameter is currently only supported by Lucee and their docs don't specify what's the default value for that parameter.

Not sure whether the note for its support should be at the parameter or at the engines. I've mentioned it in the description for the parameter itself, so it's obvious when looking at it.