### PR TITLE
Fix search redirect issue

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -63,7 +63,8 @@ $(document).ready(function() {
 //search submit
 function submitSearch(e) {
 	e.preventDefault();
-  	document.location = '/' + $('#lookup-box').val().toLowerCase();
+	var newLocation = $('#lookup-box').val().toLowerCase();
+  	document.location = (newLocation.length && newLocation[0] == '/') ? newLocation.slice(1) : newLocation;
 }
 //google analytics
 var _gaq = _gaq || [];

--- a/assets/script.js
+++ b/assets/script.js
@@ -64,7 +64,7 @@ $(document).ready(function() {
 function submitSearch(e) {
 	e.preventDefault();
 	var newLocation = $('#lookup-box').val().toLowerCase();
-  	document.location = (newLocation.length && newLocation[0] == '/') ? newLocation.slice(1) : newLocation;
+  	document.location = encodeURIComponent((newLocation.length && newLocation[0] == '/') ? newLocation.slice(1) : newLocation);
 }
 //google analytics
 var _gaq = _gaq || [];

--- a/data/en/arrayevery.json
+++ b/data/en/arrayevery.json
@@ -19,6 +19,21 @@
 		"title":"Map, Reduce and other Higher Order Functions",
 		"description":"A Primer for map, reduce, filter, and Higher Order Functions in general.",
 		"url":"http://ryanguill.com/functional/higher-order-functions/2016/05/18/higher-order-functions.html"
-	}]
-
+	}],
+	"examples": [
+		{
+			"title": "Example for positive result",
+			"description": "Checks whether all items in an array are greater than 2 and outputs true because all of them fulfill the requirement.",
+			"code": "array = [4, 5, 6, 7];\r\nwriteOutput(arrayEvery(array, function(value) { return value gt 2; }));",
+			"result": true,
+			"runnable": true
+		},
+		{
+			"title":"Example for negative result",
+			"description":"Checks whether all items in an array are greater than 2 and outputs false because some of them do not fulfill the requirement.",
+			"code":"array = [1, 2, 3, 4];\r\nwriteOutput(arrayEvery(array, function(value) { return value gt 2; }));",
+			"result":false,
+			"runnable":true
+		}
+	]
 }

--- a/data/en/componentinfo.json
+++ b/data/en/componentinfo.json
@@ -4,7 +4,7 @@
 	"syntax": "componentInfo(component)",
 	"returns": "struct",
 	"related": ["cfcomponent"],
-	"description": "",
+	"description": "Returns meta information from the passed component like \"extends\", \"hint\", etc.",
 	"params": [
 		{"name": "component", "description": "", "required": true, "default": "", "type": "component", "values": []}
 	],

--- a/data/en/dayofweekshortasstring.json
+++ b/data/en/dayofweekshortasstring.json
@@ -4,7 +4,7 @@
 	"syntax": "dayOfWeekShortAsString(day_of_week [, locale])",
 	"returns": "string",
 	"related": ["dayOfWeekAsString"],
-	"description": "",
+	"description": "Returns the first three letters of the day of the week passed to the function",
 	"params": [
 		{"name": "day_of_week", "description": "Only values from 1 to 7 are valid.\nWeek starting with 1 for Sunday and ends with 7 for Saturday.", "required": true, "default": "", "type": "numeric", "values": [1,2,3,4,5,6,7]},
 		{"name": "locale", "description": "", "required": false, "default": "", "type": "string", "values": []}

--- a/data/en/imagefilter.json
+++ b/data/en/imagefilter.json
@@ -4,7 +4,7 @@
 	"syntax": "imageFilter(name, filtername [, parameters])",
 	"returns": "void",
 	"related": ["imageFilterColorMap","imageFilterCurves","imageFilterKernel","imageFilterWarpGrid"],
-	"description": "",
+	"description": "Executes a filter on the given image",
 	"params": [
 		{"name": "name", "description": "", "required": true, "default": "", "type": "any", "values": []},
 		{"name": "filtername", "description": "", "required": true, "default": "", "type": "string", "values": []},

--- a/data/en/imageformats.json
+++ b/data/en/imageformats.json
@@ -4,11 +4,19 @@
 	"syntax": "imageFormats()",
 	"returns": "struct",
 	"related": [],
-	"description": "",
+	"description": "Returns a structure of all supported image formats that can be read (`decoder`) and written (`encoder`).",
 	"params": [],
 	"engines": {
 		"lucee": {"minimum_version": "", "notes": "", "docs": "http://docs.lucee.org/reference/functions/imageformats.html"}
 	},
-	"examples": [],
+	"examples": [
+    {
+      "title": "Simple example",
+      "description": "Calls the function and dumps the structure of image formats it returns",
+      "code": "writeDump(imageFormats());",
+      "result": "",
+      "runnable": true
+    }
+	],
 	"links": []
 }

--- a/data/en/iscustomfunction.json
+++ b/data/en/iscustomfunction.json
@@ -4,12 +4,12 @@
 	"syntax":"isCustomFunction(Object)",
 	"returns":"boolean",
 	"related":["isClosure"],
-	"description":"Determines whether a name represents a custom function",
+	"description":"Determines if a variable is a user defined function",
 	"params": [
-		{"name":"Object","description":"","required":true,"default":"","type":"any","values":[]}
+		{"name":"Object","description":"The variable to test","required":true,"default":"","type":"any","values":[]}
 	],
 	"engines": {
-		"coldfusion": {"minimum_version":"", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-in-k/iscustomfunction.html"},
+		"coldfusion": {"minimum_version":"5", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-in-k/iscustomfunction.html"},
 		"lucee": {"minimum_version":"", "notes":"", "docs":"http://docs.lucee.org/reference/functions/iscustomfunction.html"},
 		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/function/iscustomfunction"},
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/function/iscustomfunction"}

--- a/data/en/listindexexists.json
+++ b/data/en/listindexexists.json
@@ -5,7 +5,7 @@
 	"member": "list.listIndexExists(index [, delimiter] [, includeEmptyFields])",
 	"returns": "boolean",
 	"related": [],
-	"description": "",
+	"description": "Determines whether that index exists in the given list or not",
 	"params": [
 		{"name": "list", "description": "", "required": true, "default": "", "type": "string", "values": []},
 		{"name": "index", "description": "", "required": true, "default": "", "type": "numeric", "values": []},

--- a/data/en/monthshortasstring.json
+++ b/data/en/monthshortasstring.json
@@ -4,7 +4,7 @@
 	"syntax": "monthShortAsString(monthnumber)",
 	"returns": "string",
 	"related": [],
-	"description": "",
+	"description": "Returns the first three letters of the given month",
 	"params": [
 		{"name": "monthnumber", "description": "", "required": true, "default": "", "type": "numeric", "values": []}
 	],

--- a/data/en/queryrowdata.json
+++ b/data/en/queryrowdata.json
@@ -5,7 +5,7 @@
 	"member": "query.rowData(rowNumber)",
 	"returns": "struct",
 	"related": [],
-	"description": "",
+	"description": "Returns the cells of a query row as a structure",
 	"params": [
 		{"name": "query", "description": "", "required": true, "default": "", "type": "query", "values": []},
 		{"name": "rowNumber", "description": "", "required": true, "default": "", "type": "numeric", "values": []}

--- a/data/en/structfind.json
+++ b/data/en/structfind.json
@@ -1,13 +1,15 @@
 {
 	"name":"structFind",
 	"type":"function",
-	"syntax":"structFind(structure, key)",
+	"syntax":"structFind(structure, key [, defaultValue ])",
+	"member": "struct.find(key [, defaultValue ])",
 	"returns":"any",
-	"related":[],
-	"description":" Determines the value associated with a key in a structure.",
+	"related":["structFindKey", "structFindValue"],
+	"description":"Determines the value associated with a key in a structure.",
 	"params": [
-		{"name":"structure","description":"Structure that contains the value to return","required":true,"default":"","type":"struct","values":[]},
-		{"name":"key","description":"Key whose value to return","required":true,"default":"","type":"string","values":[]}
+		{"name": "structure", "description": "Structure that contains the value to return", "required": true, "default": "", "type": "struct", "values": []},
+		{"name": "key", "description": "Key whose value to return", "required": true, "default": "", "type": "string", "values": []},
+		{"name": "defaultValue", "description": "Lucee4.5+ Default value which will be returned if the key does not exist or if null was found. Currently only supported by Lucee. See http://docs.lucee.org/reference/functions/structfind.html#argument-defaultValue", "required": false, "default": "", "type": "any"}
 
 	],
 	"engines": {
@@ -16,6 +18,17 @@
 		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/function/structfind"},
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/function/structfind"}
 	},
+
+	"examples": [
+		{
+			"title": "Simple example",
+			"description": "Searches through a structure by a given key and outputs the related value",
+			"code": "countries = {\r\n    \"USA\"=\"Washington D.C.\",\r\n    \"Germany\"=\"Berlin\",\r\n    \"Japan\"=\"Tokio\"\r\n};\r\nwriteOutput(structFind(countries, \"Germany\"));",
+			"result": "Berlin",
+			"runnable": true
+		}
+	],
+
 	"links": [
 
 	]


### PR DESCRIPTION
Entering a leading `/` in the search box causes the browser to redirect outside of the domain.
e.g. `/cfimage` will result in the browser redirecting to `http://cfimage`.
Other characters appear to be filtered out at runtime. 
I've added a check in the JS for the `/`.