### PR TITLE
Corrected and clarified description of getLocaleInfo() and added a third example

### DIFF
--- a/data/en/getlocaleinfo.json
+++ b/data/en/getlocaleinfo.json
@@ -4,29 +4,34 @@
 	"syntax":"getLocaleInfo()",
 	"returns":"struct",
 	"related":["getLocaleDisplayName","getLocale","getLocaleCountry","getLocaleLanguage"],
-	"description":"A short description that describes what the tag or function does.",
-	"discouraged":"Only add this key if this tag/function is discouraged by the community.",
+	"description":"Returns a structure containing info to a specific locale.\r\n\r\nThis function combines the locale functions getLocaleCountry, getLocaleDisplayName, and getLocaleLanguage to a single function.",
 	"params": [
-		{"name":"locale","description":"Geographic/language locale value","required":true,"default":"getLocale()","type":"string","values":["en","de_DE","de_ch","..."]},
-		{"name":"displayLocale","description":"Locale's display name/Output language","required":false,"default":"getLocaleDisplayName()","type":"string","values":["English","German","French","..."]}
+		{"name":"locale", "description": "Geographic/language locale value, where the format is a combination of an <a href=\"https://en.wikipedia.org/wiki/ISO_639-1\">ISO 639-1</a> code and an optional <a href=\"https://en.wikipedia.org/wiki/ISO_3166-1\">ISO 3166-1</a> code separated by a dash or an underscore.", "required": false, "default": "getLocale()", "type":"string", "values": ["en","de-DE","de-CH","..."]},
+		{"name":"dspLocale", "description": "Locale's display name/output language", "required": false, "default": "getLocaleDisplayName()", "type": "string", "values": ["English","German","French","..."]}
 	],
 	"engines": {
-		"lucee": {"minimum_version":"5", "notes":"Combines the locale functions <code>getLocaleCountry</code>, <code>getLocaleDisplayName</code>, <code>getLocaleInfo</code>, <code>getLocaleLanguage</code> to a single function", "docs":""}
+		"lucee": {"minimum_version": "5", "notes": "", "docs": "http://docs.lucee.org/reference/functions/getlocaleinfo.html"}
 	},
 	"links": [],
 	"examples": [
 		{
-				"title": "Get information about locale",
+				"title": "Get information about the page's locale",
 				"description": "",
 				"code": "getLocaleInfo()",
 				"result": "",
-				"runnable":false
-		},{
-				"title": "Output locale in a divergent language",
-				"description": "Same as above but different country display name output",
-				"code": "getLocaleInfo(getLocale(),'French').display.country",
+				"runnable": false
+		}, {
+				"title": "Output page's locale in a divergent language",
+				"description": "Outputs the locale of the page in French.",
+				"code": "getLocaleInfo(dspLocale='French').display.country",
 				"result": "Etats-Unis",
-				"runnable":true
+				"runnable": true
+		}, {
+				"title": "Output German locale in a page's language",
+				"description": "Outputs the German locale in the language defined for the page.",
+				"code": "getLocaleInfo(locale='de-DE', dspLocale=getLocaleDisplayName()).display.country",
+				"result": "Germany",
+				"runnable": true
 		}
 	]
 }


### PR DESCRIPTION
I've added the general description for the function, removed the incorrect `"discouraged"` item, fixed the name of the second parameter, explained the parameters in more detail, added a link to the Lucee documentation, added a third example showing how to change the output language, and improved the descriptions for the existing examples.