### PR TITLE
Fix typo from isSoapReqiest to isSoapRequest

### DIFF
--- a/data/en/decision-functions.json
+++ b/data/en/decision-functions.json
@@ -1,6 +1,6 @@
 {
 	"name":"Decision Functions",
 	"type":"listing",
-	"related":["directoryExists","fileExists","fileIsEOF","iIf","isArray","isBinary","isBoolean","isCustomFunction","isDate","isDebugMode","isDDX","isDefined","isInstanceOf","isJSON","isLeapYear","isNumeric","isNumericDate","isObject","isNull","isPDFFile","isPDFObject","isQuery","isSafeHTML","isSimpleValue","isSoapReqiest","isSpreadsheetFile","isSpreadsheetObject","isStruct","isUserInAnyRole","isUserInRole","isUserLoggedIn","isValid","isWDDX","isXML","isXmlAttribute","isXmlDoc","isXmlElem","isXmlNode","isXmlRoot","lsIsCurrency","lsIsDate","lsIsNumeric","structIsEmpty","structKeyExists","yesNoFormat"],
+	"related":["directoryExists","fileExists","fileIsEOF","iIf","isArray","isBinary","isBoolean","isCustomFunction","isDate","isDebugMode","isDDX","isDefined","isInstanceOf","isJSON","isLeapYear","isNumeric","isNumericDate","isObject","isNull","isPDFFile","isPDFObject","isQuery","isSafeHTML","isSimpleValue","isSoapRequest","isSpreadsheetFile","isSpreadsheetObject","isStruct","isUserInAnyRole","isUserInRole","isUserLoggedIn","isValid","isWDDX","isXML","isXmlAttribute","isXmlDoc","isXmlElem","isXmlNode","isXmlRoot","lsIsCurrency","lsIsDate","lsIsNumeric","structIsEmpty","structKeyExists","yesNoFormat"],
 	"description":"A listing of CFML Decision Functions."
 }


### PR DESCRIPTION
Fixed typo from isSoapReqiest to isSoapRequest.  This was also resulting in a 404 when the link was clicked.