### PR TITLE
fix #904 | Example "Polyfill for ealier versions": putAll()

### DIFF
--- a/data/en/structappend.json
+++ b/data/en/structappend.json
@@ -2,7 +2,7 @@
 	"name":"structAppend",
 	"type":"function",
 	"syntax":"structAppend(destStruct, sourceStruct [, overwriteFlag])",
-	"member": "destStruct.append(sourceStruct [, overwriteFlag])\ndestStruct.putAll(sourceStruct)",
+	"member": "destStruct.append(sourceStruct [, overwriteFlag])",
 	"returns":"boolean",
 	"related":[],
 	"description":"Appends one structure to another.",
@@ -46,6 +46,13 @@
 			"code":"rc = {};\nstructAppend( rc, form );\nstructAppend( rc, url );\nwriteOutput( serializeJSON( rc ) );",
 			"result": "",
 			"runnable": false
+		},
+		{
+			"title": "Polyfill for ealier versions",
+			"description": "In older coldfusion version where this function is not supported yet, you can fall back to a native java method to achive the same behavior except that it does not have the `overwriteFlag`.",
+			"code":"config = {a:0, b:0};\noptions= {b:1, c:1};\nconfig.putAll(options);\nwriteOutput( serializeJSON( config ) );",
+			"result":"{\"A\":0,\"B\":0,\"C\":1}",
+			"runnable": true
 		}
 	]
 }


### PR DESCRIPTION
fix #904