### PR TITLE
Correct broken link in Evaluate doc page. Fixes #927

### DIFF
--- a/data/en/evaluate.json
+++ b/data/en/evaluate.json
@@ -22,7 +22,7 @@
 		{
 			"title":"Avoiding the Evalute Function",
 			"description":"Adobe Document discouraging use of Evaluate.",
-			"url":"http://help.adobe.com/en_US/ColdFusion/9.0/Developing/WSc3ff6d0ea77859461172e0811cbec09d55-7fdf.html"
+			"url":"https://helpx.adobe.com/coldfusion/developing-applications/the-cfml-programming-language/using-expressions-and-number-signs/dynamic-expressions-and-dynamic-variables.html#AvoidingtheEvaluatefunction"
 		}
 	],
 	"examples": [


### PR DESCRIPTION
Updated the link to point to the new Adobe page which discourages `Evaluate()`.