### PR TITLE
Added description to function for gettimezone

### DIFF
--- a/data/en/gettimezone.json
+++ b/data/en/gettimezone.json
@@ -4,7 +4,7 @@
 	"syntax": "getTimezone()",
 	"returns": "string",
 	"related": ["getTimezoneInfo","setTimezone","getLocale"],
-	"description": "",
+	"description": "Returns the timezone defined for the current request.",
 	"params": [],
 	"engines": {
 		"lucee": {"minimum_version": "", "notes": "", "docs": "http://docs.lucee.org/reference/functions/gettimezone.html"}


### PR DESCRIPTION
Added descrition for the function gettimezone from the Lucee documentation located here - https://docs.lucee.org/reference/functions/gettimezone.html