### PR TITLE
Marked as deprecated #Hacktoberfest

### DIFF
--- a/data/en/esapidecode.json
+++ b/data/en/esapidecode.json
@@ -10,7 +10,7 @@
 		{"name": "string", "description": "string to encode", "required": true, "default": "", "type": "string", "values": []}
 	],
 	"engines": {
-		"lucee": {"minimum_version": "", "notes": "", "docs": "http://docs.lucee.org/reference/functions/esapidecode.html"}
+		"lucee": {"minimum_version": "", "deprecated":"5", "notes": "", "docs": "http://docs.lucee.org/reference/functions/esapidecode.html"}
 	},
 	"examples": [],
 	"links": []


### PR DESCRIPTION
Fix #943
According to deprecation of esapiEncode in https://github.com/foundeo/cfdocs/commit/86cb9c68686d3de74be69ada44e6bdf65446258c