### PR TITLE
Add deprecation note to getMetricData #Hacktoberfest

### DIFF
--- a/data/en/getmetricdata.json
+++ b/data/en/getmetricdata.json
@@ -10,8 +10,8 @@
 	],
 	"engines": {
 		"coldfusion": {"minimum_version":"4.5", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-e-g/getmetricdata.html"},
-		"lucee": {"minimum_version":"", "notes":"", "docs":"http://docs.lucee.org/reference/functions/getmetricdata.html"},
-		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/function/getmetricdata"}
+		"lucee": {"minimum_version":"", "deprecated": 4, "notes":"", "docs":"http://docs.lucee.org/reference/functions/getmetricdata.html"},
+		"railo": {"minimum_version":"", "deprecated": 0, "notes":"", "docs":"http://railodocs.org/index.cfm/function/getmetricdata"}
 	},
 	"links": []
 }

--- a/data/en/getmetricdata.json
+++ b/data/en/getmetricdata.json
@@ -10,8 +10,8 @@
 	],
 	"engines": {
 		"coldfusion": {"minimum_version":"4.5", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-e-g/getmetricdata.html"},
-		"lucee": {"minimum_version":"", "deprecated": 4, "notes":"", "docs":"http://docs.lucee.org/reference/functions/getmetricdata.html"},
-		"railo": {"minimum_version":"", "deprecated": 0, "notes":"", "docs":"http://railodocs.org/index.cfm/function/getmetricdata"}
+		"lucee": {"minimum_version":"", "deprecated": "4", "notes":"", "docs":"http://docs.lucee.org/reference/functions/getmetricdata.html"},
+		"railo": {"minimum_version":"", "deprecated": "0", "notes":"", "docs":"http://railodocs.org/index.cfm/function/getmetricdata"}
 	},
 	"links": []
 }


### PR DESCRIPTION
Fix #911
According to https://github.com/lucee/Lucee/blob/5.2.9.31/core/src/main/java/lucee/runtime/functions/system/GetMetricData.java#L32