### PR TITLE
Added descriptions to arguments for listTrim and deprecated

### DIFF
--- a/data/en/listtrim.json
+++ b/data/en/listtrim.json
@@ -10,7 +10,7 @@
 		{"name": "delimiters", "description": "characters that separate list elements", "required": false, "default": ",", "type": "string", "values": []}
 	],
 	"engines": {
-		"lucee": {"minimum_version": "", "deprecated": 4, "notes": "use ListCompact instead", "docs": "http://docs.lucee.org/reference/functions/listtrim.html"}
+		"lucee": {"minimum_version": "", "deprecated": "4", "notes": "use ListCompact instead", "docs": "http://docs.lucee.org/reference/functions/listtrim.html"}
 	},
 	"examples": [],
 	"links": []

--- a/data/en/listtrim.json
+++ b/data/en/listtrim.json
@@ -7,7 +7,7 @@
 	"description": "trims leading and trailing spaces from each list element",
 	"params": [
 		{"name": "list", "description": "a string list", "required": true, "default": "", "type": "string", "values": []},
-		{"name": "delimiters", "description": "characters that separate list elements. The default value is comma.", "required": false, "default": ",", "type": "string", "values": []}
+		{"name": "delimiters", "description": "characters that separate list elements", "required": false, "default": ",", "type": "string", "values": []}
 	],
 	"engines": {
 		"lucee": {"minimum_version": "", "deprecated": 4, "notes": "use ListCompact instead", "docs": "http://docs.lucee.org/reference/functions/listtrim.html"}

--- a/data/en/listtrim.json
+++ b/data/en/listtrim.json
@@ -4,13 +4,13 @@
 	"syntax": "listTrim(list [, delimiters])",
 	"returns": "string",
 	"related": [],
-	"description": "",
+	"description": "trims leading and trailing spaces from each list element",
 	"params": [
-		{"name": "list", "description": "", "required": true, "default": "", "type": "string", "values": []},
-		{"name": "delimiters", "description": "", "required": false, "default": ",", "type": "string", "values": []}
+		{"name": "list", "description": "a string list", "required": true, "default": "", "type": "string", "values": []},
+		{"name": "delimiters", "description": "characters that separate list elements. The default value is comma.", "required": false, "default": ",", "type": "string", "values": []}
 	],
 	"engines": {
-		"lucee": {"minimum_version": "", "notes": "", "docs": "http://docs.lucee.org/reference/functions/listtrim.html"}
+		"lucee": {"minimum_version": "", "deprecated": 4, "notes": "use ListCompact instead", "docs": "http://docs.lucee.org/reference/functions/listtrim.html"}
 	},
 	"examples": [],
 	"links": []


### PR DESCRIPTION
Added descriptions to arguments from the Lucee documentation located here - https://docs.lucee.org/reference/functions/listtrim.html
And added deprecation note according to those docs and here https://github.com/lucee/Lucee/blob/5.2.9.31/core/src/main/java/lucee/runtime/functions/list/ListTrim.java#L36