### PR TITLE
Better example for duplicate() #Hacktoberfest

### DIFF
--- a/data/en/duplicate.json
+++ b/data/en/duplicate.json
@@ -16,10 +16,10 @@
 	},
 	"links": [],
 	"examples": [{
-		"title":"Copy a string and change it. Original string stays unchanged.",
-		"description":"",
-		"code":"myString = 'Hello world!';\r\nmyNewString = duplicate(myString);\r\nmyNewString = Replace(myNewString,'world','universe');\r\nwriteOutput(myString&' → '&myNewString);",
-		"result":"Hello world! → Hello universe!",
+		"title":"Changing a struct compared to changing its copy",
+		"description":"`myNewStruct` holds a reference to `myStruct` so if you change `myNewStruct`, `myStruct` is changed accordingly as well, because they are the same struct just assigned to two variables.\nIn comparison `myOtherNewStruct` is a copy so if you change `myOtherNewStruct`, `myStruct` stays untouched because with the duplicate, a new, unique structure with the same key-value pairs is created thus they do not share the same reference",
+		"code":"myStruct = {'foo': 'Lorem ipsum', 'bar': 'baz'};\n\nmyNewStruct = myStruct;\nmyOtherNewStruct = duplicate(myStruct);\n\nmyNewStruct.foo = 'ahmet sun';\nmyOtherNewStruct.foo = 'dolor sit';\n\nwriteOutput(myStruct.foo&' → '&myNewStruct.foo&' → '&myOtherNewStruct.foo);",
+		"result":"ahmet sun → ahmet sun → dolor sit",
 		"runnable":true
 	}]
 }


### PR DESCRIPTION
Fix #853
String doesn't make sense, because there is no real reference
Suggested by @jinglesthula