### PR TITLE
Update dateDiff.json

### DIFF
--- a/data/en/datediff.json
+++ b/data/en/datediff.json
@@ -2,7 +2,7 @@
 	"name":"dateDiff",
 	"type":"function",
 	"syntax":"dateDiff(datepart, date1, date2)",
-	"member":"date1.diff(datepart, date2)",
+	"member":"date2.diff(datepart, date1)",
 	"returns":"numeric",
 	"related":["dateadd","dateformat"],
 	"description":"Determines the integer number of datepart units by which date1 is less than date2.",


### PR DESCRIPTION
There is difference in dateDiff(datepart, date1, date2) and date1.diff(datepart, date2).
What is actually:
dateDiff(datepart, date1, date2) ==> date2 - date1
date1.diff(datepart, date2) ===> date1 - date2
What was documented here:
dateDiff(datepart, date1, date2) ==> date2 - date1
date1.diff(datepart, date2) ===> date2 - date1