### PR TITLE
Fix invalid currentrow usage

### DIFF
--- a/guides/en/for.md
+++ b/guides/en/for.md
@@ -40,7 +40,7 @@ For in support for native java arrays was added in CF10+
 ### For In Loop (over a query) CF10+
 
 	for (row in query) {
-		writeOutput(row.currentrow);
+		writeOutput(query.currentrow);
 	}
 
 ### Query Loop (with grouping) CF10+


### PR DESCRIPTION
`currentrow` is a member of the query object, not the index.