### PR TITLE
listAppend returns the concatenated list

### DIFF
--- a/data/en/listappend.json
+++ b/data/en/listappend.json
@@ -28,7 +28,7 @@
 			{
 				"title":"Simple listAppend Example with Delimiter",
 				"description":"Add 'foo' to the end of this list using a custom delimiter",
-				"code" : "newList = listAppend(\"bar|bar2\", \"foo\", \"|\")",
+				"code" : "oldList = \"bar,bar2\";\nnewList = listAppend(oldList, \"foo\");\nwriteOutput(oldList & \"-->\" & newList);",
 				"result":"bar|bar2|foo"
 		}
 	]

--- a/data/en/listappend.json
+++ b/data/en/listappend.json
@@ -22,7 +22,7 @@
 		{
 				"title":"Simple listAppend Example",
 				"description":"Add 'foo' to the end of this list",
-				"code" : "newList = listAppend(\"bar,bar2\", \"foo\")",
+				"code" : "oldList = \"bar,bar2\";\nnewList = listAppend(oldList, \"foo\");\nwriteOutput(oldList & \"-->\" & newList);",
 				"result":"bar,bar2,foo"
 		},
 			{

--- a/data/en/listappend.json
+++ b/data/en/listappend.json
@@ -5,7 +5,7 @@
 	"member": "str.listAppend(value [, delimiters])",
 	"returns":"string",
 	"related":["listPrepend"],
-	"description":"Concatenates a list or element to a list.",
+	"description":"Concatenates a list or element to a list and returns the concatenated list.",
 	"params": [
 		{"name":"list","description":"","required":true,"default":"","type":"string","values":[]},
 		{"name":"value","description":"An element or a list of elements.","required":true,"default":"","type":"string","values":[]},
@@ -22,13 +22,13 @@
 		{
 				"title":"Simple listAppend Example",
 				"description":"Add 'foo' to the end of this list",
-				"code" : "listAppend(\"bar,bar2\", \"foo\")",
+				"code" : "newList = listAppend(\"bar,bar2\", \"foo\")",
 				"result":"bar,bar2,foo"
 		},
 			{
 				"title":"Simple listAppend Example with Delimiter",
 				"description":"Add 'foo' to the end of this list using a custom delimiter",
-				"code" : "listAppend(\"bar|bar2\", \"foo\", \"|\")",
+				"code" : "newList = listAppend(\"bar|bar2\", \"foo\", \"|\")",
 				"result":"bar|bar2|foo"
 		}
 	]


### PR DESCRIPTION
This doc is a bit confusing when you are new to CF because unlike every other CF append function (array, struct) it isn't atomic, even when the member syntax is used. I added this to the description and the code examples to highlight this. listPrepend's doc clearly shows the proper use. Which is how I figured out what was wrong in my own code.