### PR TITLE
ArrayReverse example using different syntax in ACF2018

### DIFF
--- a/data/en/arrayreverse.json
+++ b/data/en/arrayreverse.json
@@ -25,6 +25,13 @@
 		"code":"myArray = [1,2,3]; \r\nwriteOutput( serializeJSON( myArray.reverse() ) );",
 		"result":"[3,2,1]",
 		"runnable":true
+	},
+	{
+		"title":"Reverse an Array using array slice syntax",
+		"description":"Reverse an Array using array slice syntax adding in ColdFusion 2018",
+		"code":"myArray = [1,2,3]; \r\nwriteOutput( serializeJSON( myArray[::-1] ) );",
+		"result":"[3,2,1]",
+		"runnable":true
 	}],
 	"links": []
 }


### PR DESCRIPTION
Not quite sure how to document this, but raising a PR. 

ArrayReverse does not exist in ColdFusion but you can get the same result by using the array slice syntax `[::-1]` adding in ACF 2018. Have added an example  of doing it in ACF2018, but not sure how you'd normally handle this as it's an equivalent.