### PR TITLE
Fix typo in cfmailpart

### DIFF
--- a/data/en/cfmailpart.json
+++ b/data/en/cfmailpart.json
@@ -5,7 +5,7 @@
 	"related":["cfmail"],
 	"description":"Specifies one part of a multipart e-mail message. Can only be\n used in the cfmail tag. You can use more than one cfmailpart\n tag within a cfmail tag.",
 	"params": [
-		{"name":"type","description":"The MIME media type of the part. Can be a can be valid MIME\n media type","required":true,"default":"","type":"string","values":["text\/plain","text\/html"]},
+		{"name":"type","description":"The MIME media type of the part. Can be a valid MIME\n media type","required":true,"default":"","type":"string","values":["text\/plain","text\/html"]},
 		{"name":"wraptext","description":"Specifies the maximum line length, in characters of the\n mail text. If a line has more than the specified number of\n characters, replaces the last white space character, such\n as a tab or space, preceding the specified position with a\n line break. If there are no white space characters,\n inserts a line break at the specified position. A common\n value for this attribute is 72.","required":false,"default":"","type":"numeric","values":[]},
 		{"name":"charset","description":"The character encoding in which the part text is encoded.\n\n For more information on character encodings, see:\n www.w3.org\/International\/O-charset.html.","required":false,"default":"","type":"string","values":["utf-8","iso-8859-1","windows-1252","us-ascii","shift_jis","iso-2022-jp","euc-jp","euc-kr","big5","euc-cn","utf-16"]}
 	],


### PR DESCRIPTION
Just some repeated characters. `type can be a valid MIME`