### PR TITLE
Add docs for `properties` parameter in entityNew

### DIFF
--- a/data/en/entitynew.json
+++ b/data/en/entitynew.json
@@ -6,7 +6,8 @@
 	"related":["entityDelete"],
 	"description":" Creates a new instance of the persistent CFC with the entity name that you provide.",
 	"params": [
-		{"name":"entityName","description":"Entity name of the persistent CFC.","required":true,"default":"","type":"string","values":[]}
+		{"name":"entityName","description":"Entity name of the persistent CFC.","required":true,"default":"","type":"string","values":[]},
+		{"name":"properties","description":"Struct of data to populate new entity","required":false,"default":"","type":"struct","values":[]}
 	],
 	"engines": {
 		"coldfusion": {"minimum_version":"", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-e-g/entitynew.html"},


### PR DESCRIPTION
This is documented in Lucee: https://docs.lucee.org/reference/functions/entitynew.html and ACF: https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-e-g/entitynew.html.

If I wasn't so lazy, I'd add an example while I was at it. :)