### PR TITLE
Mark encodeFor* functions as *not* deprecated

### DIFF
--- a/data/en/encodefor.json
+++ b/data/en/encodefor.json
@@ -3,7 +3,7 @@
 	"type":"function",
 	"syntax":"encodeFor(type, value)",
 	"returns":"string",
-	"related":["encodeForHTML", "canonicalize"],
+	"related":["encodeForHTML", "canonicalize","esapiEncode"],
 	"description":"Encodes a given string for safe output in the specified context. The encoding is meant to mitigate Cross Site Scripting (XSS) attacks.",
 	"params": [
 		{"name":"type","description":"The context of the encoding to perform.","required":true,"default":"","type":"string","values":["css","dn","html","htmlattribute","javascript","ldap","url","xml","xmlattribute","xpath"]},

--- a/data/en/encodeforcss.json
+++ b/data/en/encodeforcss.json
@@ -11,7 +11,7 @@
 	],
 	"engines": {
 		"coldfusion": {"minimum_version":"10", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-e-g/encodeforcss.html"},
-		"lucee": {"minimum_version":"4.5", "notes":"This function has been deprecated. Use `ESAPIEncode('css',...)` instead.", "docs":"http://docs.lucee.org/reference/functions/encodeforcss.html", "deprecated":"5"},
+		"lucee": {"minimum_version":"4.5", "notes":"", "docs":"http://docs.lucee.org/reference/functions/encodeforcss.html"},
 		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/function/EncodeForCSS"}
 	},
 	"links": [],

--- a/data/en/encodefordn.json
+++ b/data/en/encodefordn.json
@@ -11,7 +11,7 @@
 	],
 	"engines": {
 		"coldfusion": {"minimum_version":"10", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-e-g/encodefordn.html"},
-		"lucee": {"minimum_version":"4.5", "notes":"This function is deprecated, use function ESAPIEncode('dn',...) instead.", "docs":"http://docs.lucee.org/reference/functions/encodefordn.html","deprecated":"5"},
+		"lucee": {"minimum_version":"4.5", "notes":"", "docs":"http://docs.lucee.org/reference/functions/encodefordn.html"},
 		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/function/EncodeForDN"}
 	},
 	"links": [

--- a/data/en/encodeforhtml.json
+++ b/data/en/encodeforhtml.json
@@ -11,7 +11,7 @@
 	],
 	"engines": {
 		"coldfusion": {"minimum_version":"10", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-e-g/encodeforhtml.html"},
-		"lucee": {"minimum_version":"4.5", "notes":"This function has been deprecated. Use `ESAPIEncode('css',...)` instead.", "docs":"http://docs.lucee.org/reference/functions/encodeforhtml.html", "deprecated":"5"}
+		"lucee": {"minimum_version":"4.5", "notes":"", "docs":"http://docs.lucee.org/reference/functions/encodeforhtml.html"}
 	},
 	"links": [
         {

--- a/data/en/encodeforhtmlattribute.json
+++ b/data/en/encodeforhtmlattribute.json
@@ -11,7 +11,7 @@
 	],
 	"engines": {
 		"coldfusion": {"minimum_version":"10", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-e-g/encodeforhtmlattribute.html"},
-		"lucee": {"minimum_version":"4.5", "notes":"This function has been deprecated. Use `ESAPIEncode('html_attr',...)` instead.", "docs":"http://docs.lucee.org/reference/functions/encodeforhtmlattribute.html", "deprecated":"5"}
+		"lucee": {"minimum_version":"4.5", "notes":"", "docs":"http://docs.lucee.org/reference/functions/encodeforhtmlattribute.html"}
 	},
 	"links": [
         {

--- a/data/en/encodeforjavascript.json
+++ b/data/en/encodeforjavascript.json
@@ -12,7 +12,7 @@
 	],
 	"engines": {
 		"coldfusion": {"minimum_version":"10", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-e-g/encodeforjavascript.html"},
-		"lucee": {"minimum_version":"4.5", "notes":"This function has been deprecated. Use `ESAPIEncode('javascript',...)` instead.", "docs":"http://docs.lucee.org/reference/functions/encodeforjavascript.html", "deprecated":"5"}
+		"lucee": {"minimum_version":"4.5", "notes":"", "docs":"http://docs.lucee.org/reference/functions/encodeforjavascript.html"}
 	},
 	"links": [
         {

--- a/data/en/encodeforldap.json
+++ b/data/en/encodeforldap.json
@@ -11,7 +11,7 @@
 	],
 	"engines": {
 		"coldfusion": {"minimum_version":"11", "notes":"Works on CF11+ but not documented.", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-by-category/display-and-formatting-functions.html"},
-		"lucee": {"minimum_version":"4.5", "notes":"This function has been deprecated. Use `ESAPIEncode('ldap',...)` instead.", "docs":"http://docs.lucee.org/reference/functions/encodeforldap.html", "deprecated":"5"},
+		"lucee": {"minimum_version":"4.5", "notes":"", "docs":"http://docs.lucee.org/reference/functions/encodeforldap.html"},
 		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/function/EncodeForLDAP"}
 	},
 	"links": [],

--- a/data/en/encodeforurl.json
+++ b/data/en/encodeforurl.json
@@ -11,7 +11,7 @@
 	],
 	"engines": {
 		"coldfusion": {"minimum_version":"10", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-e-g/encodeforurl.html"},
-		"lucee": {"minimum_version":"4.5", "notes":"This function has been deprecated. Use `ESAPIEncode('url',...)` instead.", "docs":"http://docs.lucee.org/reference/functions/encodeForURL.html", "deprecated":"5"},
+		"lucee": {"minimum_version":"4.5", "notes":"", "docs":"http://docs.lucee.org/reference/functions/encodeForURL.html"},
 		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/function/encodeForURL"},
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/function/encodeForURL"}
 	},

--- a/data/en/encodeforxml.json
+++ b/data/en/encodeforxml.json
@@ -11,7 +11,7 @@
 	],
 	"engines": {
 		"coldfusion": {"minimum_version":"10", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-e-g/encodeforxml.html"},
-		"lucee": {"minimum_version":"4.5", "notes":"This function has been deprecated. Use `ESAPIEncode('xml',...)` instead.", "docs":"http://docs.lucee.org/reference/functions/encodeforxml.html", "deprecated":"5"},
+		"lucee": {"minimum_version":"4.5", "notes":"", "docs":"http://docs.lucee.org/reference/functions/encodeforxml.html"},
 		"railo": {"minimum_version":"4.0", "notes":"", "docs":"http://railodocs.org/index.cfm/function/encodeForXML"}
 	},
 	"links": [],

--- a/data/en/encodeforxmlattribute.json
+++ b/data/en/encodeforxmlattribute.json
@@ -11,7 +11,7 @@
 	],
 	"engines": {
 		"coldfusion": {"minimum_version":"11", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-e-g/encodeforxmlattribute.html"},
-		"lucee": {"minimum_version":"4.5", "notes":"This function has been deprecated. Use `ESAPIEncode('xml_attr',...)` instead.", "docs":"http://docs.lucee.org/reference/functions/encodeforxmlattribute.html", "deprecated":"5"},
+		"lucee": {"minimum_version":"4.5", "notes":"", "docs":"http://docs.lucee.org/reference/functions/encodeforxmlattribute.html"},
 		"railo": {"minimum_version":"4", "notes":"", "docs":"http://railodocs.org/index.cfm/function/EncodeForXMLAttribute"}
 	},
 	"links": [

--- a/data/en/encodeforxpath.json
+++ b/data/en/encodeforxpath.json
@@ -11,7 +11,7 @@
 	],
 	"engines": {
 		"coldfusion": {"minimum_version":"11", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-e-g/encodeforxpath.html"},
-		"lucee": {"minimum_version":"4.5", "notes":"This function has been deprecated. Use `ESAPIEncode('xpath',...)` instead.", "docs":"http://docs.lucee.org/reference/functions/encodeforxpath.html", "deprecated":"5"},
+		"lucee": {"minimum_version":"4.5", "notes":"", "docs":"http://docs.lucee.org/reference/functions/encodeforxpath.html"},
 		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/function/EncodeForXPath"}
 	},
 	"links": [],


### PR DESCRIPTION
The decision to deprecate these `encodeForHTML()`, `encodeFor*()` functions has been reversed per Brad Wood and others more informed than I. :)
See https://groups.google.com/forum/#!topic/lucee/90xgx_wnVs4,
https://cfml.slack.com/messages/C06TA0A9W/convo/C06TA0A9W-1558749781.016600/