### PR TITLE
Add default value for `scale` argument of cfqueryparam

### DIFF
--- a/data/en/cfqueryparam.json
+++ b/data/en/cfqueryparam.json
@@ -90,7 +90,7 @@
       "name": "scale",
       "description": "Number of decimal places in parameter. Applies to `CF_SQL_NUMERIC` and `CF_SQL_DECIMAL`.",
       "required": false,
-      "default": "",
+      "default": "0",
       "type": "numeric",
       "values": []
     },


### PR DESCRIPTION
As shown in https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-tags/tags-p-q/cfqueryparam.html, and as experienced by my upgrade from CF2016 to CF2018 this morning.