### PR TITLE
Add Lucee `encodeFor` support note to writeOutput

### DIFF
--- a/data/en/writeoutput.json
+++ b/data/en/writeoutput.json
@@ -7,7 +7,7 @@
 	"description":" Appends text to the page-output stream.\n This function writes to the page-output stream regardless of\n conditions established by the cfsetting tag.",
 	"params": [
 		{"name":"string","description":"A string, or a variable that contains one","required":true,"default":"","type":"string","values":[]},
-		{"name":"encodeFor","description":"CF2016+ Wraps the result with an encodeFor function.","required":false,"default":"","type":"string","values":["html","htmlattribute","javascript","css","xml","xmlattribute","url","xpath","ldap","dn"]}
+		{"name":"encodeFor","description":"CF2016+ Lucee5.1.0.8+ Wraps the result with an encodeFor function.","required":false,"default":"","type":"string","values":["html","htmlattribute","javascript","css","xml","xmlattribute","url","xpath","ldap","dn"]}
 	],
 	"engines": {
 		"coldfusion": {"minimum_version":"4", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-t-z/writeoutput.html"},


### PR DESCRIPTION
Lucee 5.1.0.8+ supports the `encodeFor` attribute on `writeOutput()`. I'm not certain that tag `Lucee5.1.0.8+` will work, but here goes. :)

(If that tag doesn't work, should we update the engine regex or just note it as "Since Lucee 5.2+`?

https://docs.lucee.org/reference/functions/writeoutput.html