### PR TITLE
Typo: "Adode" to "Adobe" in canonicalize() code examples

### DIFF
--- a/data/en/canonicalize.json
+++ b/data/en/canonicalize.json
@@ -25,13 +25,13 @@
         },
         {
             "title": "Enforce multiple and mixed encoding detection",
-            "description": "(Adode CF11+ example with `throwOnError` parameter set to true) Enforce multiple and mixed encoding detection. Mixed encoding is detected as the data is encoded using URL and HTML entity encoding. Multiple Encoding is also detected.",
+            "description": "(Adobe CF11+ example with `throwOnError` parameter set to true) Enforce multiple and mixed encoding detection. Mixed encoding is detected as the data is encoded using URL and HTML entity encoding. Multiple Encoding is also detected.",
             "code": "<cftry>\n\t<cfoutput>#canonicalize(\"%26lt; %26lt; %2526lt%253B %2526lt%253B %2526lt%253B\",true,true, true)#</cfoutput><br/>\n\t<cfcatch type=\"any\" >\n\t\t<!--- throws Error when throwOnError set to true (CF11+) when mixed or multiple encoding is detected. --->\n\t\t<cfdump var=\"#cfcatch#\" >\n\t</cfcatch>\n</cftry>",
             "result": "Error Message: Input validation failure. The log message will contain more detailed information on the error."
         },
         {
             "title": "Enforce multiple and mixed encoding detection",
-            "description": "(Adode CF11+ example with `throwOnError` parameter set to false) Enforce multiple and mixed encoding detection. Mixed encoding is detected as the data is encoded using URL and HTML entity encoding. Multiple Encoding is also detected.",
+            "description": "(Adobe CF11+ example with `throwOnError` parameter set to false) Enforce multiple and mixed encoding detection. Mixed encoding is detected as the data is encoded using URL and HTML entity encoding. Multiple Encoding is also detected.",
             "code": "<!--- an Empty string will be returned if the throwOnError is set to false and multiple or mixed encoding is found --->\n<cfoutput>#canonicalize(\"%26lt; %26lt; %2526lt%253B %2526lt%253B %2526lt%253B\",true,true, false)#</cfoutput>",
             "result": "[Empty string]"
         },


### PR DESCRIPTION
Quick typo fix, thanks!