### PR TITLE
Lucee isValid() update

### DIFF
--- a/data/en/isclosure.json
+++ b/data/en/isclosure.json
@@ -4,7 +4,7 @@
 	"syntax":"isClosure(object)",
 	"returns":"boolean",
 	"description":"Checks if a given object is a closure.",
-	"related": ["isCustomFunction"],
+	"related": ["isCustomFunction", "isClosure"],
 	"params": [
 		{"name":"object","description":"The object to check if it is a closure.","required":true,"default":"","type":"any","values":[]}
 	],

--- a/data/en/isclosure.json
+++ b/data/en/isclosure.json
@@ -4,7 +4,7 @@
 	"syntax":"isClosure(object)",
 	"returns":"boolean",
 	"description":"Checks if a given object is a closure.",
-	"related": ["isCustomFunction", "isClosure"],
+	"related": ["isCustomFunction", "isValid"],
 	"params": [
 		{"name":"object","description":"The object to check if it is a closure.","required":true,"default":"","type":"any","values":[]}
 	],

--- a/data/en/isimage.json
+++ b/data/en/isimage.json
@@ -3,7 +3,7 @@
 	"type":"function",
 	"syntax":"isImage(name)",
 	"returns":"boolean",
-	"related":[],
+	"related":["isValid"],
 	"description":" Determines whether a variable returns a ColdFusion image.",
 	"params": [
 		{"name":"name","description":"No Help Available","required":true,"default":"","type":"string","values":[]}

--- a/data/en/isvalid.json
+++ b/data/en/isvalid.json
@@ -6,7 +6,7 @@
 	"related":["isarray", "issimplevalue","isnumeric","isboolean","isdate","cfparam"],
 	"description":"Tests whether a value meets a validation or data type rule.",
 	"params": [
-		{"name":"type","description":"The valid format for the data.","required":true,"default":"","type":"string","values":["any","array","binary","boolean","cfc (same as component)","component","class (same as component)","closure","creditcard","date","datetime","email","eurodate (not recommended)","float","function","guid","integer","image","node (same as XML)","number","numeric","phone (same as telephone)","query","range","regex","regular_expression","ssn","social_security_number","string","struct","telephone","time","URL","UUID","usdate","variablename","XML","zip (same as zipcode)","zipcode"]},
+		{"name":"type","description":"The valid format for the data.","required":true,"default":"","type":"string","values":["any","array","binary","boolean","cfc","component","class","closure","creditcard","date","datetime", "datetime_object", "email","eurodate","float","function","guid","integer","image","number","numeric","phone","query","range","regex","regular_expression","ssn","social_security_number","string","struct","telephone","time","URL","UUID","usdate","variablename","XML","zip","zipcode"]},
 		{"name":"value","description":"The value to test.","required":true,"default":"","type":"any","values":[]},
 		{"name":"min","description":"The minimum valid value; used only for range validation.","required":false,"default":"","type":"numeric","values":[]},
 		{"name":"max","description":"The maximum valid value; used only for range validation.","required":false,"default":"","type":"numeric","values":[]},
@@ -14,8 +14,8 @@
 
 	],
 	"engines": {
-		"coldfusion": {"minimum_version":"7", "notes":"CF8+ - added component as a type option.\nCF11+ - no longer allows currency symbols at the start and commas inside a number. Can be reverted to legacy mode by setting this.strictNumberValidation = false in Application.cfc", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-in-k/isvalid.html"},
-		"lucee": {"minimum_version":"", "notes":"", "docs":"https://docs.lucee.org/reference/functions/isvalid.html"},
+		"coldfusion": {"minimum_version":"7", "notes":"CF8+ - added component as a type option.\nCF11+ - no longer allows currency symbols at the start and commas inside a number. Can be reverted to legacy mode by setting this.strictNumberValidation = false in Application.cfc.\nCF2016+ - added datetime_object as a type option.", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-in-k/isvalid.html"},
+		"lucee": {"minimum_version":"", "notes":"The types any, cfc, class, closure, float, function, image, number, phone, XML, and zip are Lucee-only.", "docs":"https://docs.lucee.org/reference/functions/isvalid.html"},
 		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/function/isvalid"},
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/function/isvalid"}
 	},

--- a/data/en/isvalid.json
+++ b/data/en/isvalid.json
@@ -6,11 +6,11 @@
 	"related":["isarray", "issimplevalue","isnumeric","isboolean","isdate","cfparam"],
 	"description":"Tests whether a value meets a validation or data type rule.",
 	"params": [
-		{"name":"type","description":"The valid format for the data.","required":true,"default":"","type":"string","values":["Any","Array","Binary","boolean","closure","creditcard","date","time","email","eurodate","float","Numeric","guid","integer","Query","range","Regex","regular_expression","ssn","social_security_number","String","Struct","telephone","URL","UUID","usdate","variablename","xml","zipcode","component"]},
+		{"name":"type","description":"The valid format for the data.","required":true,"default":"","type":"string","values":["any","array","binary","boolean","cfc (same as component)","component","class (same as component)","closure","creditcard","date","datetime","email","eurodate (not recommended)","float","function","guid","integer","image","node (same as XML)","number","numeric","phone (same as telephone)","query","range","regex","regular_expression","ssn","social_security_number","string","struct","telephone","time","URL","UUID","usdate","variablename","XML","zip (same as zipcode)","zipcode"]},
 		{"name":"value","description":"The value to test.","required":true,"default":"","type":"any","values":[]},
-		{"name":"min","description":"The minimum valid value; used only for range validation.","required":true,"default":"","type":"numeric","values":[]},
-		{"name":"max","description":"The maximum valid value; used only for range validation.","required":true,"default":"","type":"numeric","values":[]},
-		{"name":"pattern","description":"A regular expression that the parameter must match;\n used only for regex or regular_expression validation.","required":true,"default":"","type":"string","values":[]}
+		{"name":"min","description":"The minimum valid value; used only for range validation.","required":false,"default":"","type":"numeric","values":[]},
+		{"name":"max","description":"The maximum valid value; used only for range validation.","required":false,"default":"","type":"numeric","values":[]},
+		{"name":"pattern","description":"A regular expression that the parameter must match;\n used only for regex or regular_expression validation.","required":false,"default":"","type":"string","values":[]}
 
 	],
 	"engines": {

--- a/data/en/isvalid.json
+++ b/data/en/isvalid.json
@@ -6,7 +6,7 @@
 	"related":["isarray", "issimplevalue","isnumeric","isboolean","isdate","cfparam"],
 	"description":"Tests whether a value meets a validation or data type rule.",
 	"params": [
-		{"name":"type","description":"The valid format for the data.","required":true,"default":"","type":"string","values":["Any","Array","Binary","boolean","creditcard","date","time","email","eurodate","float","Numeric","guid","integer","Query","range","Regex","regular_expression","ssn","social_security_number","String","Struct","telephone","URL","UUID","usdate","variablename","xml","zipcode","component"]},
+		{"name":"type","description":"The valid format for the data.","required":true,"default":"","type":"string","values":["Any","Array","Binary","boolean","closure","creditcard","date","time","email","eurodate","float","Numeric","guid","integer","Query","range","Regex","regular_expression","ssn","social_security_number","String","Struct","telephone","URL","UUID","usdate","variablename","xml","zipcode","component"]},
 		{"name":"value","description":"The value to test.","required":true,"default":"","type":"any","values":[]},
 		{"name":"min","description":"The minimum valid value; used only for range validation.","required":true,"default":"","type":"numeric","values":[]},
 		{"name":"max","description":"The maximum valid value; used only for range validation.","required":true,"default":"","type":"numeric","values":[]},


### PR DESCRIPTION
Added a bunch of types that Lucee supports in `isValid()`.

https://github.com/lucee/Lucee/blob/dbb220d72027fea68f927654388456515289867a/core/src/main/java/lucee/runtime/op/Decision.java#L972-L1047

Some of them are new and useful, like `isValid("lambda", x)` or `isValid("image", xyz)`, while others are merely aliases. (For example, I love the idea of using `isValid("class", myObject)` over `isValid("component", myObject)`.)

As I type up this PR, I realize that I should have added `Lucee5+` to each Lucee-only type, as I'm certain these are all or mostly all Lucee-only.

Sigh. Maybe tomorrow.