### PR TITLE
Provided examples and clarification

### DIFF
--- a/data/en/systemoutput.json
+++ b/data/en/systemoutput.json
@@ -4,7 +4,7 @@
 	"syntax": "systemOutput(obj [, addNewLine] [, doErrorStream])",
 	"returns": "boolean",
 	"related": [],
-	"description": "Writes the given string to the output stream",
+	"description": "Writes the given object to the output stream",
 	"params": [
 		{"name": "obj", "description": "", "required": true, "default": "", "type": "any", "values": []},
 		{"name": "addNewLine", "description": "", "required": false, "default": "", "type": "boolean", "values": []},
@@ -13,6 +13,21 @@
 	"engines": {
 		"lucee": {"minimum_version": "", "notes": "", "docs": "https://docs.lucee.org/reference/functions/systemoutput.html"}
 	},
-	"examples": [],
+	"examples": [{
+		"title":"Write a string to the output stream \"Hello World\"",
+		"description":"",
+		"code":"systemOutput(\"Hello World\");"
+	},
+     	{
+		"title":"Write an array to the output stream",
+		"description":"",
+		"code":"systemOutput([ \"foo\", \"bar\" ]);"
+	},
+     	{
+		"title":"Write a struct to the output stream",
+		"description":"",
+		"code":"systemOutput({ \"myKey\", \"myValue\" });"
+	}
+    	],
 	"links": []
 }


### PR DESCRIPTION
Provided a few examples of how you can use the `systemOutput()` function to write different object types to the output stream.  I also clarified the description to use the word "object" instead of "string" for clarification.