### PR TITLE
Replaced invalid parameter name, filePath, with valid parameter name,…

### DIFF
--- a/data/en/fileappend.json
+++ b/data/en/fileappend.json
@@ -1,12 +1,12 @@
 {
 	"name":"fileAppend",
 	"type":"function",
-	"syntax":"fileAppend(filePath, data [, charset])",
+	"syntax":"fileAppend(file, data [, charset])",
 	"returns":"void",
 	"related":["filewrite"],
 	"description":"Appends the data contents to the file.",
 	"params": [
-		{"name":"filePath","description":"File path","required":true,"default":"","type":"string","values":[]},
+		{"name":"file","description":"File path","required":true,"default":"","type":"string","values":[]},
 		{"name":"data","description":"Data to append to the file","required":true,"default":"","type":"string","values":[]},
 		{"name":"charset","description":"The character encoding in which the file contents is encoded.","required":false,"default":"","type":"string","values":[]},
 		{"name":"addNewLine","description":"CF2016u11+ Indicates whether a new line is added to the end of the appended data","required":false,"default":"true","type":"boolean","values":[]}


### PR DESCRIPTION
… file.

Also opened ticket with Adobe to update their documentation: https://tracker.adobe.com/#/view/CF-4206170
Incorrect filePath example: https://cffiddle.org/app/file?filepath=81ae5d05-815f-4c6d-9913-2195d6efc79e/9d7da6c2-5579-4890-9f18-10767f0e641d/91207523-5823-4d04-bd0e-364728b068e1.cfm
Correct file example: https://cffiddle.org/app/file?filepath=a005cf45-0972-4b25-8f16-2d4e3225893e/47ba5661-9490-4a91-a5c1-3b5e8aa24112/c8a85c0c-4467-4228-82b3-0ae1508f2e81.cfm