### PR TITLE
Fix bad example for Lucee's nullValue() function

### DIFF
--- a/data/en/nullvalue.json
+++ b/data/en/nullvalue.json
@@ -12,7 +12,7 @@
 	"examples": [{
             "title":"ColdFusion polyfill",
             "description":"Using java data type null instead",
-            "code":"nullValue = javacast('null','');\nwriteOutput(isNull(nullValue));",
+            "code":"writeOutput(isNull(nullValue()));",
             "result":"YES",
             "runnable":true
         }],


### PR DESCRIPTION
Current example doesn't use the method it's supposed to be demonstrating.