### PR TITLE
Fix terminateOnTimeout docs for cfexecute

### DIFF
--- a/data/en/cfexecute.json
+++ b/data/en/cfexecute.json
@@ -12,11 +12,11 @@
 		{"name":"timeout","description":"Length of time, in seconds, that CFML waits for\n output from the spawned program.","required":false,"default":0,"type":"numeric","values":[]},
 		{"name":"errorVariable","description":"The name of a variable in which to save the error stream output.","required":false,"default":"","type":"string","values":[]},
 		{"name":"errorFile","description":"The pathname of a file in which to save the error stream output. If not an\nabsolute path (starting a with a drive letter and a colon, or a forward or backward slash), it is\nrelative to the ColdFusion temporary directory, which is returned by the GetTempDirectory\nfunction.","required":false,"default":"","type":"string","values":[]},
-		{"name":"terminateOnTimeout","description":"Lucee4.5+ Terminate the process after the specified timeout is reached. Ignored if timeout is not set or is 0.","required":false,"default":"false","type":"boolean","values":[true, false]}
+		{"name":"terminateOnTimeout","description":"Lucee Terminate the process after the specified timeout is reached. Ignored if timeout is not set or is 0.","required":false,"default":"false","type":"boolean","values":[true, false]}
 	],
 	"engines": {
-		"coldfusion": {"minimum_version":"4.5", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-tags/tags-d-e/cfexecute.html"},
-		"lucee": {"minimum_version":"", "notes":"terminateOnTimeout isn't supported in Lucee", "docs":"https://docs.lucee.org/reference/tags/execute.html"},
+		"coldfusion": {"minimum_version":"", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-tags/tags-d-e/cfexecute.html"},
+		"lucee": {"minimum_version":"", "notes":"terminateOnTimeout is only supported in Lucee 4.5+", "docs":"https://docs.lucee.org/reference/tags/execute.html"},
 		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/tag/cfexecute"},
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/tag/cfexecute"}
 	},

--- a/data/en/cfexecute.json
+++ b/data/en/cfexecute.json
@@ -12,11 +12,11 @@
 		{"name":"timeout","description":"Length of time, in seconds, that CFML waits for\n output from the spawned program.","required":false,"default":0,"type":"numeric","values":[]},
 		{"name":"errorVariable","description":"The name of a variable in which to save the error stream output.","required":false,"default":"","type":"string","values":[]},
 		{"name":"errorFile","description":"The pathname of a file in which to save the error stream output. If not an\nabsolute path (starting a with a drive letter and a colon, or a forward or backward slash), it is\nrelative to the ColdFusion temporary directory, which is returned by the GetTempDirectory\nfunction.","required":false,"default":"","type":"string","values":[]},
-		{"name":"terminateOnTimeout","description":"Lucee Terminate the process after the specified timeout is reached. Ignored if timeout is not set or is 0.","required":false,"default":"false","type":"boolean","values":[true, false]}
+		{"name":"terminateOnTimeout","description":"Lucee4.5+ Terminate the process after the specified timeout is reached. Ignored if timeout is not set or is 0.","required":false,"default":"false","type":"boolean","values":[true, false]}
 	],
 	"engines": {
-		"coldfusion": {"minimum_version":"", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-tags/tags-d-e/cfexecute.html"},
-		"lucee": {"minimum_version":"", "notes":"terminateOnTimeout is only supported in Lucee 4.5+", "docs":"https://docs.lucee.org/reference/tags/execute.html"},
+		"coldfusion": {"minimum_version":"4.5", "notes":"terminateOnTimeout is not supported in Adobe ColdFusion", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-tags/tags-d-e/cfexecute.html"},
+		"lucee": {"minimum_version":"", "notes":"", "docs":"https://docs.lucee.org/reference/tags/execute.html"},
 		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/tag/cfexecute"},
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/tag/cfexecute"}
 	},


### PR DESCRIPTION
I'm not sure about the listed version numbers, but it looks like there's some confusion.

The ACF docs history section only references a change made in ACF6.1 (adding the `variable` attribute), with no mention of initial addition of the method.

Likewise, the Lucee docs don't mention when the method was added.

For that reason, I've removed the version numbers referenced here. Hopefully the feature is old enough that it doesn't matter any more. :)