### PR TITLE
not just null

### DIFF
--- a/guides/en/elvis.md
+++ b/guides/en/elvis.md
@@ -33,6 +33,8 @@ Similarly, you can use this operator for Struct:
 
     securityNumber = securityStruct['Joe'] ?: "";
 
+NB: If the value tested === false, then the expression on the right will be evaluated.
+
 ## Examples
 
 Examples which are all the same:

--- a/guides/en/elvis.md
+++ b/guides/en/elvis.md
@@ -33,7 +33,7 @@ Similarly, you can use this operator for Struct:
 
     securityNumber = securityStruct['Joe'] ?: "";
 
-NB: If the value tested === false, then the expression on the right will be evaluated.
+NB: In CF if the value tested === false, then the expression on the right will be evaluated. https://tracker.adobe.com/#/view/CF-4198933 Lucee behaves as expected.
 
 ## Examples
 


### PR DESCRIPTION
Updated to warn other what I just discovered, and that is that if the value being tested is false, then the value on the right is used. This resulted in a true / false variable with a default of true always being true.