### PR TITLE
Add missing encodeFor functions to security list

### DIFF
--- a/data/en/security-functions.json
+++ b/data/en/security-functions.json
@@ -1,6 +1,6 @@
 {
 	"name":"Security Functions",
 	"type":"listing",
-	"related":["binaryDecode","binaryEncode","CSRFGenerateToken","CSRFVerifyToken","decrypt","decryptBinary","encodeForHTML","encodeForHTMLAttribute","encodeForURL","encrypt","encryptBinary","generatePBKDFKey","generateSecretKey","getAuthUser","getTempDirectory","getTempFile","getUserRoles","hash","hmac","isUserInAnyRole","isUserInRole","isUserLoggedIn","SSLCertificateInstall","SSLCertificateList","verifyClient"],
+	"related":["binaryDecode","binaryEncode","CSRFGenerateToken","CSRFVerifyToken","decrypt","decryptBinary","encodeFor","encodeForCSS","encodeForDN","encodeForHTML","encodeForHTMLAttribute","encodeForJavaScript","encodeForLDAP","encodeForURL","encodeForXML","encodeForXMLAttribute","encodeForXPath","encrypt","encryptBinary","generatePBKDFKey","generateSecretKey","getAuthUser","getTempDirectory","getTempFile","getUserRoles","hash","hmac","isUserInAnyRole","isUserInRole","isUserLoggedIn","SSLCertificateInstall","SSLCertificateList","verifyClient"],
 	"description":"A listing of CFML Security Functions."
 }


### PR DESCRIPTION
There may be other functions missing from this list, but these were the ones I was looking for that were missing. I believe I got all of the `encodeForXYZ` functions, which was my intent.