### PR TITLE
Added ability to set default TryCF engine per example

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ We need help expanding existing tag and function documentation. Look through the
                 "description":"Description of the code example",
                 "code":"<cf_examplecodehere>",
                 "result":"The expected output of the code example",
-                "runnable":true
+                "runnable":true,
+                "engine":"Default engine to use in tryCF example. (lucee,lucee5,railo,acf,acf11,acf2016,*acf2018,acf2021)"
             }
         ]
     }

--- a/assets/code-editor.js
+++ b/assets/code-editor.js
@@ -109,9 +109,10 @@ angular.module('code.editor', [])
 	'		             	<option value="lucee5">Lucee 5.LATEST</option>'+
 	'		             	<option value="lucee">Lucee 4.5.LATEST</option>'+
 	'		             	<option value="railo">Railo 4.2</option>'+
-	'				<option value="acf2018">Adobe ColdFusion 2018</option>'
-	'				<option value="acf2016">Adobe ColdFusion 2016</option>'+
-	'				<option value="acf11">Adobe ColdFusion 11</option>'+
+	'						<option value="acf2021">Adobe ColdFusion 2021</option>'+
+	'						<option value="acf2018">Adobe ColdFusion 2018</option>'+
+	'						<option value="acf2016">Adobe ColdFusion 2016</option>'+
+	'						<option value="acf11">Adobe ColdFusion 11</option>'+
 	'		             	<option value="acf">Adobe ColdFusion 10</option>'+
 	'		         </select>'+
 	'		        </div>'+
@@ -174,7 +175,7 @@ angular.module('code.editor', [])
 				scope.setupCodeGist = attrs.setupCodeGist;
 				scope.asserts = attrs.asserts;
 				scope.fullscreen = attrs.fullscreen;
-				scope.engines = {'acf2018':'Adobe ColdFusion 2018','acf2016':'Adobe ColdFusion 2016','acf11':'Adobe ColdFusion 11', 'acf':'Adobe ColdFusion 10', 'railo':'Railo 4.2', 'lucee':'Lucee 4.5', 'lucee5':'Lucee 5', 'lucee5.0.0.45':'Lucee 5.0.0.45'};
+				scope.engines = {'acf2021':'Adobe ColdFusion 2021','acf2018':'Adobe ColdFusion 2018','acf2016':'Adobe ColdFusion 2016','acf11':'Adobe ColdFusion 11', 'acf':'Adobe ColdFusion 10', 'railo':'Railo 4.2', 'lucee':'Lucee 4.5', 'lucee5':'Lucee 5', 'lucee5.0.0.45':'Lucee 5.0.0.45'};
 				scope.engine = attrs.engine || 'lucee';
 				scope.basepath = attrs.basepath || '/gist/';
 
@@ -207,13 +208,14 @@ angular.module('code.editor', [])
 					showResults = typeof attrs.showResults !== 'undefined' ? attrs.showResults === "true" || attrs.showResults === "1" : true,
                     urlPool = {
                     	"railo" : [ "https://railo-sbx.trycf.com/getremote.cfm" ],
-		    	"lucee" : [ "https://lucee4-sbx.trycf.com/lucee4/getremote.cfm" ],
-		    	"lucee5" : [ "https://lucee5-sbx.trycf.com/lucee5/getremote.cfm" ],
-		    	"lucee5.0.0.45" : [ "https://lucee5-sbx.trycf.com/lucee5/getremote.cfm" ],
-                    	"acf" 	: [ "https://acf10-sbx.trycf.com/cfusion/getremote.cfm" ],
-			"acf11" : [ "https://acf11-sbx.trycf.com/cfusion/getremote.cfm" ],
-			"acf2016" : [ "https://acf12-sbx.trycf.com/getremote.cfm" ],
-			"acf2018" : [ "https://acf13-sbx.trycf.com/getremote.cfm" ]
+				    	"lucee" : [ "https://lucee4-sbx.trycf.com/lucee4/getremote.cfm" ],
+				    	"lucee5" : [ "https://lucee5-sbx.trycf.com/lucee5/getremote.cfm" ],
+				    	"lucee5.0.0.45" : [ "https://lucee5-sbx.trycf.com/lucee5/getremote.cfm" ],
+		                "acf" : [ "https://acf10-sbx.trycf.com/cfusion/getremote.cfm" ],
+						"acf11" : [ "https://acf11-sbx.trycf.com/cfusion/getremote.cfm" ],
+						"acf2016" : [ "https://acf12-sbx.trycf.com/getremote.cfm" ],
+						"acf2018" : [ "https://acf13-sbx.trycf.com/getremote.cfm" ],
+						"acf2021" : [ "https://acf14-sbx.trycf.com/getremote.cfm" ]
                     },
                     url = attrs.url || urlPool[scope.engine][Math.floor(Math.random()*urlPool[scope.engine].length)];
 

--- a/assets/script.js
+++ b/assets/script.js
@@ -44,7 +44,8 @@ $(document).ready(function() {
 	  $('.example-btn').click(function() {
 	      var name = $(this).attr('data-name');
 	      var index = $(this).attr('data-index');
-	      $('#example-modal-content').html('<iframe width="100%" height="450" border="0" src="/try/' + name + '/' + index + '">');
+	      var engine = $(this).attr('data-engine');
+	      $('#example-modal-content').html('<iframe width="100%" height="450" border="0" src="/try/' + name + '/' + index + '/' + engine +'">');
 	      $('.example-modal').modal();      
 	  });
 

--- a/data/cfdocs.schema.json
+++ b/data/cfdocs.schema.json
@@ -398,6 +398,11 @@
             "title": "Runnable",
             "description": "Whether the code is runnable",
             "type": "boolean"
+          },
+          "engine": {
+            "title": "Engine",
+            "description": "The default engine to use in the cftry modal",
+            "type": "string"
           }
         },
         "required": [

--- a/data/en/structdelete.json
+++ b/data/en/structdelete.json
@@ -2,6 +2,7 @@
 	"name":"structDelete",
 	"type":"function",
 	"syntax":"structDelete(structure, key [, indicateNotExisting])",
+	"member": "someStruct.delete(key)",
 	"returns":"boolean",
 	"related":["structclear"],
 	"description":"Removes an element from a structure.",
@@ -22,8 +23,16 @@
 		{
 			"title": "Remove a key from a struct",
 			"description": "Creates a struct then removes a key",
-			"code": "someStruct = {a=1,b=2};\nstructDelete(someStruct, \"a\");\nwriteDump(someStruct);",
-			"result": ""
-		}
+			"code": "someStruct = {a=1,b=2};\nstructDelete(someStruct, \"a\");\n\nwriteDump(someStruct);",
+			"result": "true",
+			"runnable": true
+		},
+	    {
+	    	"title": "Remove a key from a struct using the member function",
+	    	"description": "CF11+ Lucee4.5+ Invoking the delete function on a struct is the same as running structDelete.",
+	    	"code": "someStruct = {a=1, b=2};\nsomeStruct.delete('a');\n\nwriteDump(someStruct);",
+	    	"result": "true",
+	    	"runnable": true
+	    }
 	]
 }

--- a/data/en/structnew.json
+++ b/data/en/structnew.json
@@ -77,25 +77,29 @@
       "title": "New case-sensitive struct using function",
       "description": "CF2021+ Creates a case-sensitive struct.",
       "code": "casesensitive = structNew( \"casesensitive\" );\r\ncasesensitive.a = 1;\r\ncasesensitive.B = 2;\r\ncasesensitive.c = 3;\r\nwriteDump( casesensitive );",
-      "result": ""
+      "result": "",
+      "engine": "acf2021"
     },
     {
       "title": "New case-sensitive struct using literal notation",
       "description": "CF2021+ Creates a case-sensitive struct.",
       "code": "casesensitive = ${a=1, B=2, c=3};\r\nwriteDump( casesensitive );",
-      "result": ""
+      "result": "",
+      "engine": "acf2021"
     },
     {
       "title": "New ordered and case-sensitive struct using function",
       "description": "CF2021+ Creates a case-sensitive struct.",
       "code": "someStruct = structNew( \"ordered-casesensitive\" );\r\nsomeStruct.c = 3;\r\nsomeStruct.B = 2;\r\nsomeStruct.a = 1;\r\nwriteDump( someStruct );",
-      "result": ""
+      "result": "",
+      "engine": "acf2021"
     },
     {
       "title": "New ordered and case-sensitive struct using literal notation",
       "description": "CF2021+ Creates an ordered and case-sensitive struct.",
       "code": "someStruct = $[c=3, B=2, a=1];\r\nwriteDump( someStruct );",
-      "result": ""
+      "result": "",
+      "engine": "acf2021"
     }
   ]
 }

--- a/data/en/structnew.json
+++ b/data/en/structnew.json
@@ -8,12 +8,14 @@
   "params": [
     {
       "name": "structType",
-      "description": "CF2016+ Lucee4.5+ If set to `ordered` the order in which elements are added to the structure will be maintained. In Lucee `linked` can be used in place of `ordered`.",
+      "description": "CF2016+ Lucee4.5+ If set to `ordered` the order in which elements are added to the structure will be maintained. In Lucee `linked` can be used in place of `ordered`.\r\nCF2021+ If set to `casesensitive` the keys will remain case-sensitive. Additionally, `ordered-casesensitive` can be used to create an ordered case-sensitive struct.",
       "required": false,
       "default": "",
       "type": "string",
       "values": [
-        "ordered"
+        "ordered",
+        "casesensitive",
+        "ordered-casesensitive"
       ]
     }
   ],
@@ -69,6 +71,30 @@
       "title": "New ordered struct using literal notation",
       "description": "CF2016+ Lucee5+ Creates an ordered struct.",
       "code": "ordered = [:];\r\nordered.a = 1;\r\nordered.b = 2;\r\nordered.c = 3;\r\nwriteDump( ordered );",
+      "result": ""
+    },
+    {
+      "title": "New case-sensitive struct using function",
+      "description": "CF2021+ Creates a case-sensitive struct.",
+      "code": "casesensitive = structNew( \"casesensitive\" );\r\ncasesensitive.a = 1;\r\ncasesensitive.B = 2;\r\ncasesensitive.c = 3;\r\nwriteDump( casesensitive );",
+      "result": ""
+    },
+    {
+      "title": "New case-sensitive struct using literal notation",
+      "description": "CF2021+ Creates a case-sensitive struct.",
+      "code": "casesensitive = ${a=1, B=2, c=3};\r\nwriteDump( casesensitive );",
+      "result": ""
+    },
+    {
+      "title": "New ordered and case-sensitive struct using function",
+      "description": "CF2021+ Creates a case-sensitive struct.",
+      "code": "someStruct = structNew( \"ordered-casesensitive\" );\r\nsomeStruct.c = 3;\r\nsomeStruct.B = 2;\r\nsomeStruct.a = 1;\r\nwriteDump( someStruct );",
+      "result": ""
+    },
+    {
+      "title": "New ordered and case-sensitive struct using literal notation",
+      "description": "CF2021+ Creates an ordered and case-sensitive struct.",
+      "code": "someStruct = $[c=3, B=2, a=1];\r\nwriteDump( someStruct );",
       "result": ""
     }
   ]

--- a/data/en/structreduce.json
+++ b/data/en/structreduce.json
@@ -2,7 +2,7 @@
     "name":"structReduce",
     "type":"function",
     "syntax":"structReduce(struct, function(result, key, value [,struct]){} [, initialVal])",
-    "script":"someStruct.reduce(function(result, key, value [,struct]){} [, initialVal])",
+    "member": "someStruct.reduce(function(result, key, value [,struct]){} [, initialVal])",
     "returns":"any",
     "related":["structEach","structSome","structMap","structFilter"],
     "description":"Iterates over every entry of the struct and calls the closure to work on the key value pair of the struct. This function will reduce the struct to a single value and will return the value.",

--- a/rewrites.xml
+++ b/rewrites.xml
@@ -5,6 +5,10 @@
         <to>/trycf.cfm?name=$1&amp;index=$2</to>
     </rule>
     <rule>
+        <from>^/try/([^./]+)/([0-9]+)/([acefiloru0-9]{3,10})?$</from>
+        <to>/trycf.cfm?name=$1&amp;index=$2&amp;engine=$3</to>
+    </rule>
+    <rule>
         <from>^/([^./]+)$</from>
         <to>/doc.cfm?name=$1</to>
     </rule>

--- a/trycf.cfm
+++ b/trycf.cfm
@@ -9,6 +9,7 @@
     <cfelse>
         <cfset data={title="404"}>
     </cfif>
+    <cfset url.engine = listFindNoCase('acf,acf11,acf2016,acf2018,acf2021,lucee,lucee5,railo', url.engine)? lCase(url.engine) : 'acf2018'>
     <cfif structKeyExists(data.engines, "lucee") AND NOT structKeyExists(data.engines, "coldfusion")>
         <cfset url.engine = "lucee5">
     </cfif>

--- a/trycf.cfm
+++ b/trycf.cfm
@@ -1,6 +1,7 @@
 <cfparam name="url.name" default="rereplace">
 <cfparam name="url.index" default="1" type="numeric">
 <cfparam name="url.engine" default="acf2018" type="variablename">
+
 <cfsilent>
     <cfset url.name = ReReplace(url.name, "[^a-zA-Z0-9_-]", "", "ALL")>
     <cfif FileExists(ExpandPath("./data/en/#url.name#.json"))>

--- a/utilities/json/index.cfm
+++ b/utilities/json/index.cfm
@@ -37,6 +37,18 @@
 				<option value="1" selected="selected">Yes - Show Run Code Button</option>
 			</select>
 			<br>
+
+			<select name="engine" class="form-control">
+				<option value="lucee5">Lucee 5.LATEST</option>
+				<option value="lucee">Lucee 4.5.LATEST</option>
+				<option value="railo">Railo 4.2</option>
+				<option value="acf2021">Adobe ColsFusion 2021</option>
+				<option value="acf2018" selected="selected">Adobe ColdFusion 2018</option>
+				<option value="acf2016">Adobe ColdFusion 2016</option>
+				<option value="acf11">Adobe ColdFusion 11</option>
+				<option value="acf">Adobe ColdFusion 10</option>
+			</select>
+			<br>
 			<input type="submit" value="To JSON" class="btn btn-primary">
 		</form>
 

--- a/utilities/json/json.cfm
+++ b/utilities/json/json.cfm
@@ -9,7 +9,7 @@
 	<cfparam name="form.description" default="">
 	<cfparam name="form.result" default="">
 	<cfparam name="form.runnable" default="1">
-
+	<cfparam name="form.engine" default="acf2018">
 <cfoutput>
 <cfsavecontent variable="json">
 {
@@ -17,7 +17,8 @@
 	"description":#serializeJSON(form.description)#,
 	"code":#serializeJSON(form.code)#,
 	"result":#serializeJSON(form.result)#,
-	"runnable":<cfif isBoolean(form.runnable) AND form.runnable>true<cfelse>false</cfif>
+	"runnable":<cfif isBoolean(form.runnable) AND form.runnable>true<cfelse>false</cfif>,
+	"engine":#serializeJson(form.engine)#
 }
 </cfsavecontent>
 </cfoutput>

--- a/views/doc.cfm
+++ b/views/doc.cfm
@@ -288,7 +288,7 @@
 						<div class="panel-body">
 							<cfif NOT structKeyExists(ex, "runnable") OR ex.runnable>
 								<div class="pull-right">
-									<button class="example-btn btn btn-default" data-name="#encodeForHTMLAttribute(LCase(data.name))#" data-index="#example_index#"><span class="glyphicon glyphicon-play-circle"></span>&nbsp; Run Code</button>
+									<button class="example-btn btn btn-default" data-name="#encodeForHTMLAttribute(LCase(data.name))#" data-index="#example_index#" data-engine="#encodeForHTMLAttribute(LCase(ex?.engine))#"><span class="glyphicon glyphicon-play-circle"></span>&nbsp; Run Code</button>
 								</div>
 							</cfif>
 							<p class="clearfix">#autoLink(ex.description)#</p>


### PR DESCRIPTION
Submitting this as a separate PR because I don't know if this is a feature you'll find useful.  This feature adds the ability to set the default engine on an example so the user doesn't have to select it if it's example is engine specific (ie: CF2021 structNew case-sensitive feature).