### PR TITLE
ColumnType "timestamp" was missing

### DIFF
--- a/data/en/queryaddcolumn.json
+++ b/data/en/queryaddcolumn.json
@@ -8,7 +8,8 @@
 	"params": [
 		{"name":"query","description":"","required":true,"default":"","type":"query","values":[]},
 		{"name":"column_name","description":"","required":true,"default":"","type":"string","values":[]},
-		{"name":"datatype","description":"Column data type.","required":false,"default":"","type":"string","values":["Integer","Bigint","Double","Decimal","Varchar","Binary","Bit","Time","Date"]},
+		{"name":"datatype","description":"Column data type.","required":false,"default":"","type":"string","values":["Integer","Bigint","Double","Decimal","Varchar","Binary","Bit","Time",
+"Date","Timestamp"]},
 		{"name":"array_name","description":"","required":true,"default":"","type":"array","values":[]}
 
 	],


### PR DESCRIPTION
ColumnType `timestamp` is supported in every cfml application server.  Adobe incorrectly states in their [documentation](https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-m-r/queryaddcolumn.html) that "Date (can include time information)", but it doesn't and hasn't since CF11. (Specifying `date` ignores all time values.)