### PR TITLE
Fix member syntax example

### DIFF
--- a/data/en/queryaddcolumn.json
+++ b/data/en/queryaddcolumn.json
@@ -38,7 +38,7 @@
 		{
 			"title":"member syntax example",
 			"description":"add a column to a query using member syntax",
-			"code":"books = queryNew(\"id,title\", \"integer,varchar\");\nbooks.addRow(\"author\", \"varchar\");\nwriteDump(books);",
+			"code":"books = queryNew(\"id,title\", \"integer,varchar\");\nbooks.addColumn(\"author\", \"varchar\", []);\nwriteDump(books);",
 			"result":"",
 			"runnable":true
 		}


### PR DESCRIPTION
Existing example shows `addRow` instead of `addColumn` and misses an array argument.