### PR TITLE
Update queryclear.json (missing params?)

### DIFF
--- a/data/en/queryclear.json
+++ b/data/en/queryclear.json
@@ -6,7 +6,7 @@
     "returns":"query",
     "description":"This function takes a query, removes all the rows, then returns a query object with no records",
     "params": [
-		{"name":"query","description":"","required":true,"default":"","type":"query","values":[]},
+		{"name":"query","description":"","required":true,"default":"","type":"query","values":[]}
     ],
     "engines":{
         "coldfusion":{"minimum_version":"2018.0.5", "notes":"New tag in Update 5", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-m-r/queryclear.html"}

--- a/data/en/queryclear.json
+++ b/data/en/queryclear.json
@@ -5,6 +5,9 @@
     "member":"query.clear()",
     "returns":"query",
     "description":"This function takes a query, removes all the rows, then returns a query object with no records",
+    "params": [
+		{"name":"query","description":"","required":true,"default":"","type":"query","values":[]},
+    ],
     "engines":{
         "coldfusion":{"minimum_version":"2018.0.5", "notes":"New tag in Update 5", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-m-r/queryclear.html"}
     },


### PR DESCRIPTION
I don't know if this is a bug in this project (is the JSON schema intended to always have a `params`?), or in KamasamaK's plugin; but the absence of a `params` field is unexpected in the KamasamaK plugin, and is met with an exception on a failing read in `CfDocsDefinitionInfo::toGlobalFunction`

so this could be fixed here, but might not be correct if it doesn't matter to CfDocs that there is no `params` field.