### PR TITLE
Update arrayeach.json

### DIFF
--- a/data/en/arrayeach.json
+++ b/data/en/arrayeach.json
@@ -3,7 +3,7 @@
 	"type":"function",
 	"syntax":"arrayEach(array, function(item, [index, [array]]){} [, parallel] [, maxThreads])",
 	"member":"someArray.each(function(item, [index, [array]]){} [, parallel] [, maxThreads])",
-	"returns":"void",
+	"returns":"void (on ACF). Returns the original array on Lucee",
 	"related":["arrayMap", "arrayReduce"],
 	"description":"Used to iterate over an array and run the function closure for each item in the array.",
 	"params": [


### PR DESCRIPTION
The "each" member functions return the original array on Lucee so they are chainable.  In all of the years of using cfdocs as my primary documentation source, I didn't find this out until last week...