### PR TITLE
fix blog post link

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you don't want to go the commandbox route you can simply download it and unzi
 
 ## How to contribute
 
-If you are interested in contributing going I suggest you fork it, see Adam Tuttle's guide: [GitHub tip for your first pull request](https://adamtuttle.codes/your-first-github-pull-request/)
+If you are interested in contributing going I suggest you fork it, see Adam Tuttle's guide: [GitHub tip for your first pull request](https://adamtuttle.codes/blog/2014/your-first-github-pull-request/)
 
 If you are interested in helping you can just copy a tag or function and write up some documentation. The documentation doesn't need to be super wordy and should not be a copy of Adobe's documentation word for word.
 
@@ -45,7 +45,7 @@ CFDocs.org is meant to be a quick reference so keep it short and sweet. E.g. att
 
 #### The better way to edit the docs
 
-1. fork the project to your GitHub account *need help? read this: [GitHub tip for your first pull request](http://adamtuttle.codes/blog/2014/your-first-github-pull-request/)*
+1. fork the project to your GitHub account *need help? read this: [GitHub tip for your first pull request](https://adamtuttle.codes/blog/2014/your-first-github-pull-request/)*
 2. clone it locally
 3. make your changes
 4. test it locally using commandbox (see above)


### PR DESCRIPTION
Found that this link was now getting a 404. Here's the new URL.