### PR TITLE
Improve writeBody function and normalize case of other functions

### DIFF
--- a/data/en/componentinfo.json
+++ b/data/en/componentinfo.json
@@ -9,7 +9,7 @@
 		{"name": "component", "description": "", "required": true, "default": "", "type": "component", "values": []}
 	],
 	"engines": {
-		"lucee": {"minimum_version": "", "deprecated":"4.5", "notes": "In Lucee4.5+ `componentInfo()` is deprecated in favor of `getMetaData()`", "docs": "https://docs.lucee.org/reference/functions/componentinfo.html"}
+		"lucee": {"minimum_version": "", "deprecated":"4.5", "notes": "In Lucee4.5+ `componentInfo()` is deprecated in favor of `getMetadata()`", "docs": "https://docs.lucee.org/reference/functions/componentinfo.html"}
 	},
 	"examples": [],
 	"links": []

--- a/data/en/getmetadata.json
+++ b/data/en/getmetadata.json
@@ -21,17 +21,17 @@
 	],
 	"examples": [
 		{
-			"title":"Dump MetaData of CFC Instance",
+			"title":"Dump Metadata of CFC Instance",
 			"description":"CF9+",
-			"code":"writeDump(getMetaData(new Query()));",
+			"code":"writeDump(getMetadata(new Query()));",
 			"result":""
 		},
 		{
-			"title":"Dump MetaData of Array",
+			"title":"Dump Metadata of Array",
 			"description":"CF2018+ Struct has a new key called <i>dimensions</i> and can also have a defined datatype. Supported datatypes are String, Numeric, Boolean, Date, Array, Struct, Query, Component, Binary, and Function.",
 			"code":"arr = arrayNew['String'](1);\nwriteDump(arr.getMetadata());",
 			"result":""
-		}		
+		}
 	]
 
 }

--- a/data/en/imagegetexifmetadata.json
+++ b/data/en/imagegetexifmetadata.json
@@ -1,8 +1,8 @@
 {
-	"name":"imageGetExifMetaData",
+	"name":"imageGetEXIFMetadata",
 	"type":"function",
-	"syntax":"imageGetExifMetaData(name)",
-	"member":"someImage.getExifMetaData()",
+	"syntax":"imageGetEXIFMetadata(name)",
+	"member":"someImage.getEXIFMetadata()",
 	"returns":"struct",
 	"related":["imageGetEXIFTag"],
 	"description":"Retrieves the Exchangeable Image File Format (EXIF) headers in an image as a CFML structure.",
@@ -18,9 +18,9 @@
 	"links": [],
 	"examples": [
 		{
-			"title":"Using getExifMetaData member function",
+			"title":"Using getEXIFMetadata member function",
 			"description":"CF11+ Lucee4.5+ Extract the EXIF meta data from exiv sample page (http://www.exiv2.org/sample.html)",
-			"code":"imgObj = imageRead(\"http://www.exiv2.org/include/img_1771.jpg\");\r\nx = imgObj.getExifMetaData();\r\nwriteDump(x);",
+			"code":"imgObj = imageRead(\"http://www.exiv2.org/include/img_1771.jpg\");\r\nx = imgObj.getEXIFMetadata();\r\nwriteDump(x);",
 			"result":"",
 			"runnable":true
 		}

--- a/data/en/imagegetexiftag.json
+++ b/data/en/imagegetexiftag.json
@@ -4,7 +4,7 @@
 	"syntax":"imageGetEXIFTag(name, tagName)",
 	"member":"someImage.getEXIFTag(tagName)",
 	"returns":"string",
-	"related":["imageGetExifMetaData"],
+	"related":["imageGetEXIFMetadata"],
 	"description":" Retrieves the specified EXIF tag in an image.",
 	"params": [
 		{"name":"name","description":"The image on which this operation is performed.","required":true,"default":"","type":"string","values":[]},

--- a/data/en/imagegetiptcmetadata.json
+++ b/data/en/imagegetiptcmetadata.json
@@ -1,8 +1,8 @@
 {
-	"name":"imageGetIPTCMetaData",
+	"name":"imageGetIPTCMetadata",
 	"type":"function",
-	"syntax":"imageGetIPTCMetaData(name)",
-	"member":"someImage.getIPTCMetaData()",
+	"syntax":"imageGetIPTCMetadata(name)",
+	"member":"someImage.getIPTCMetadata()",
 	"returns":"struct",
 	"related":["cfimage", "ImageGetBlob", "ImageGetBufferedImage", "ImageGetEXIFMetadata", "ImageGetEXIFTag", "ImageGetHeight","ImageGetWidth", "ImageGetIPTCTag", "ImageInfo", "IsImage", "IsImageFile"],
 	"description":" Retrieves the International Press Telecommunications Council (IPTC )headers in a ColdFusion image as a structure.",
@@ -18,9 +18,9 @@
 	],
 	"examples": [
 		{
-			"title":"Using getIPTCMetaData member function",
+			"title":"Using getIPTCMetadata member function",
 			"description":"CF11+ Extract the IPTC meta data from IPTC image (https://code.google.com/p/metadata-extractor/wiki/SampleOutput)",
-			"code":"imgObj = imageRead(\"http://sample-images.metadata-extractor.googlecode.com/git/FujiFilm%20FinePixS1Pro%20(1).jpg\");\r\nx = imgObj.getIPTCMetaData();\r\nwriteDump(x);",
+			"code":"imgObj = imageRead(\"http://sample-images.metadata-extractor.googlecode.com/git/FujiFilm%20FinePixS1Pro%20(1).jpg\");\r\nx = imgObj.getIPTCMetadata();\r\nwriteDump(x);",
 			"result":"",
 			"runnable":true
 		}

--- a/data/en/onmissingmethod.json
+++ b/data/en/onmissingmethod.json
@@ -20,7 +20,7 @@
  		{
 			"title":"onMissingMethod Example",
 			"description":"Creates helper function getPropertyNameForHTML() which calls getPropertyName() and wraps it with the encodeForHTML function.",
-			"code":"public function onMissingMethod(missingMethodName, missingMethodArguments) {\r\n    if (reFindNoCase(\"^get[a-zA-Z0-9]+ForHTML$\", arguments.missingMethodName) {\r\n        local.getter = this[replaceNoCase(arguments.missingMethodName, \"ForHTML\", \"\")];\r\n        return encodeForHTML(local.getter());\r\n    } else {\r\n        throw (message=\"Method #encodeForHTML(arguments.missingMethodName)# was not found in the component #encodeForHTML(GetMetaData(this).name)#\");\r\n    }\r\n}",
+			"code":"public function onMissingMethod(missingMethodName, missingMethodArguments) {\r\n    if (reFindNoCase(\"^get[a-zA-Z0-9]+ForHTML$\", arguments.missingMethodName) {\r\n        local.getter = this[replaceNoCase(arguments.missingMethodName, \"ForHTML\", \"\")];\r\n        return encodeForHTML(local.getter());\r\n    } else {\r\n        throw (message=\"Method #encodeForHTML(arguments.missingMethodName)# was not found in the component #encodeForHTML(getMetadata(this).name)#\");\r\n    }\r\n}",
 			"result":"",
 			"runnable":false
 		}

--- a/data/en/structsetmetadata.json
+++ b/data/en/structsetmetadata.json
@@ -18,7 +18,7 @@
 		{
 			"title":"Add metadata to a struct",
 			"description":"Add metadata to a struct and serialze to a json.\nIt is changing the keyname and convert a string (\"20\") to a number.",
-			"code":"testStruct = structNew(\"ordered\");\ntestStruct.testdata = \"example\";\ntestStruct.testdata2 = \"20\";\nmetadata = {\n    testdata: {type: \"string\", name: \"td1\" },\n    testdata2: {type: \"numeric\", name: \"td2\" }\n};\nStructSetMetaData(testStruct,metadata);\nwriteoutput(SerializeJSON(testStruct));",
+			"code":"testStruct = structNew(\"ordered\");\ntestStruct.testdata = \"example\";\ntestStruct.testdata2 = \"20\";\nmetadata = {\n    testdata: {type: \"string\", name: \"td1\" },\n    testdata2: {type: \"numeric\", name: \"td2\" }\n};\nStructSetMetadata(testStruct,metadata);\nwriteoutput(SerializeJSON(testStruct));",
 			"result":"{\"td1\":\"example\", \"td2\":20.0}",
 			"runnable": true
 		},

--- a/data/en/writebody.json
+++ b/data/en/writebody.json
@@ -1,17 +1,17 @@
 {
 	"name":"writeBody",
 	"type":"function",
-	"syntax":"writeBody();",
-	"returns":"void",
-	"related":[],
-	"description":" n/a",
+	"syntax":"writeBody(value);",
+	"returns":"boolean",
+	"related":["writeOutput"],
+	"description":" Writes an output to a page. WriteBody should be used within a tag with a body only.",
 	"params": [
-
+		{"name":"value","description":"A string or any variable that can evaluate to a string.","required":true,"default":"","type":"string","values":[]}
 	],
 	"engines": {
+		"coldfusion": {"minimum_version":"", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-t-z/writebody.html"}
 	},
 	"links": [
-
 	],
 	"examples": [
 


### PR DESCRIPTION
I added more information to the writeBody function.  I found that the return value is boolean in that the function returns "YES" if successful.  I don't know of a way to have it return "NO", however.  If the return is not "YES", then the only other result is an error.  So, technically, it returns a boolean, but in this instance, the return value is practically useless.

I also normalized the use of "Metadata" and "EXIF" within function names.