### PR TITLE
Issue #1447 - Finished side note in cftransaction description

### DIFF
--- a/data/en/cftransaction.json
+++ b/data/en/cftransaction.json
@@ -4,7 +4,7 @@
 	"syntax":"<cftransaction>",
 	"script": "transaction { }",
 	"related":["cftry", "cfcatch","transactioncommit","transactionrollback","transactionsetsavepoint"],
-	"description":"Instructs the database management system to treat multiple\n database operations as a single transaction. Provides database\n commit and rollback processing.\r\nNote that distributed transactions (transactions across multiple datasources) are not supported - you must commit one transaction and begin a separate transaction to ",
+	"description":"Instructs the database management system to treat multiple\n database operations as a single transaction. Provides database\n commit and rollback processing.\r\nNote that distributed transactions (transactions across multiple datasources) are not supported - you must commit one transaction and begin a separate transaction to one database before writing a query to another (CFMX7 Manual)",
 	"params": [
 		{"name":"action","description":"`begin`: the start of the block of code to execute\n`commit`: commits a pending transaction\n`rollback`: rolls back a pending transaction\n`setsavepoint`: Marks a place within the transaction as a savepoint.","required":false,"default":"begin","type":"string","values":["begin","commit","rollback","setsavepoint"]},
 		{"name":"isolation","description":"ODBC lock type.","required":false,"default":"","type":"string","values":["read_uncommitted","read_committed","repeatable_read","serializable"]},


### PR DESCRIPTION
The cftransaction page has a side note in its description that does not complete the sentence. To resolve this issue, I researched where this side note could have surfaced. It was found in the _CFMX7 manual_ according to user Newsgroup_User in the Adobe Support Community responding to this very topic. I finished the sentence as part of the reference.

Adobe Support Community Answer - [https://community.adobe.com/t5/coldfusion-discussions/cftransaction-amp-multiple-data-sources/m-p/844868](https://community.adobe.com/t5/coldfusion-discussions/cftransaction-amp-multiple-data-sources/m-p/844868)


> Newsgroup_User
> _LEGEND , May 25, 2006_
> This has been copied and pasted straight from the CFMX7 manual -
> "Within a transaction block, you can write queries to more than one
> database, but you must commit or roll back a transaction to one database
> before writing a query to another." ....