### PR TITLE
enable prettify to highlight syntax on guides

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -47,7 +47,7 @@ $(document).ready(function() {
 	      $('#example-modal-content').html('<iframe width="100%" height="450" border="0" src="/try/' + name + '/' + index + '">');
 	      $('.example-modal').modal();      
 	  });
-
+	  if(!$("pre").hasClass('prettyprint')) $("pre").addClass('prettyprint');
 	  if ($('.prettyprint').length != 0 && typeof(prettyPrint) == "function") {
 	      prettyPrint();
 	  }

--- a/doc.cfm
+++ b/doc.cfm
@@ -3,6 +3,8 @@
 <cfif url.name IS "index">
 	<cfset data = {name="CFDocs", description="Ultra Fast CFML Documentation", type="index"}>
 <cfelseif FileExists(ExpandPath("./guides/en/#url.name#.md")) OR url.name is "how-to-contribute">
+
+	<cfset request.hasExamples = true>
 	<cftry>
 		<!--- convert md to HTML --->
 		<cfset txtmark = createObject("java", "com.github.rjeschke.txtmark.Processor")>


### PR DESCRIPTION
This was missing due to guides not having examples so the code didn't know to load the libraries, plus since the code examples were in markdown, the code blocks were missing the `.prettyprint` class. 

This was easily fixed just by applying the class before running the pretty print function and adding `request.hasExamples = true` for the guides pages
![code highlight sbs](https://user-images.githubusercontent.com/5215594/166553959-e352ba5d-f98f-4331-ad8a-a115a8714bd8.jpeg)
