### PR TITLE
Fix cachePut value type

### DIFF
--- a/data/en/cacheput.json
+++ b/data/en/cacheput.json
@@ -7,7 +7,7 @@
 	"description":"Stores an object in the cache.",
 	"params": [
 		{"name":"id","description":"Unique identifier for the cached value","required":true,"default":"","type":"string","values":[]},
-		{"name":"value","description":"The value to cache","required":true,"default":"","type":"string","values":[]},
+		{"name":"value","description":"The value to cache","required":true,"default":"","type":"any","values":[]},
 		{"name":"timespan","description":"The interval until the object is flushed from the cache, as a decimal number of days. One way to set the value is to use the return value from the CreateTimeSpan function. The default is to not time out the object.","required":false,"default":"","type":"date","values":[]},
 		{"name":"idleTime","description":"A decimal number of days after which the object is flushed from the cache if it is not accessed during that time. One way to set the value is to use the return value from the CreateTimeSpan function.","required":false,"default":"","type":"date","values":[]},
 		{"name":"region","description":"Lucee4.5+ CF10+ Specifies the cache region/name where you place the cache object.","required":false,"default":"","type":"string","values":[]},
@@ -24,21 +24,21 @@
 		{
 			"title": "Tag Syntax",
 			"description": "",
-			"code": "<cfset cachedData = cacheGet(\"wt-6-cache\")>\r\n<!--- If the data is not cached, create it and do a cache put. --->\r\n<cfif isNull(cachedData)>\r\n\tCache doesn't exist, so create it.<br />\r\n\t<cfset sleep(1000)>\r\n\t<cfset cachedData = \"This date/time IS cached: #now()#<br />\">\r\n\t<cfoutput>#cachedData#</cfoutput> \r\n\t<cfset cachePut(\"wt-6-cache\", cachedData, createTimespan(0,0,0,10))>\r\n</cfif>",
+			"code": "<cfset cachedData = cacheGet(\"wt-6-cache\")>\n<!--- If the data is not cached, create it and do a cache put. --->\n<cfif isNull(cachedData)>\n\tCache doesn't exist, so create it.<br />\n\t<cfset sleep(1000)>\n\t<cfset cachedData = \"This date/time IS cached: #now()#<br />\">\n\t<cfoutput>#cachedData#</cfoutput> \n\t<cfset cachePut(\"wt-6-cache\", cachedData, createTimespan(0,0,0,10))>\n</cfif>",
 			"result": "",
-            		"runnable":false
+			"runnable":false
 		},
 		{
 			"title":"Script Syntax",
 			"description":"I place data into the default cache.",
-			"code":"<cfscript>\r\n// generate some data to cache\r\ndata = { bar = 'foo', foo = 'bar' };\r\n\r\n// add the data to a named cache\r\ncachePut( 'cached_object_name_or_id', data, createTimeSpan( 0, 0, 30, 0 ), createTimeSpan( 0, 0, 15, 0 ) );\r\n</cfscript>",
+			"code":"// generate some data to cache\ndata = { bar = 'foo', foo = 'bar' };\n\n// add the data to a named cache\ncachePut( 'cached_object_name_or_id', data, createTimeSpan( 0, 0, 30, 0 ), createTimeSpan( 0, 0, 15, 0 ) );",
 			"result":"",
 			"runnable":false
 		},
 		{
 			"title":"Script Syntax - Named Cache",
 			"description":"I place data into a named cache. CF10+ Lucee4.5+",
-			"code":"<cfscript>\r\n// generate some data to cache\r\ndata = { bar = 'foo', foo = 'bar' };\r\n\r\n// add the data to a named cache\r\ncachePut( 'cached_object_name_or_id', data, createTimeSpan( 0, 0, 30, 0 ), createTimeSpan( 0, 0, 15, 0 ), 'region_cacheName' );\r\n</cfscript>",
+			"code":"// generate some data to cache\ndata = { bar = 'foo', foo = 'bar' };\n\n// add the data to a named cache\ncachePut( 'cached_object_name_or_id', data, createTimeSpan( 0, 0, 30, 0 ), createTimeSpan( 0, 0, 15, 0 ), 'region_cacheName' );",
 			"result":"",
 			"runnable":false
 		}


### PR DESCRIPTION
Changed the `type` for the param `value` of `cachePut` from `string` to `any`.

Also removed the unnecessary `cfscript` tags.