### PR TITLE
Auto-generated guides order tags/functions alphabetically

### DIFF
--- a/guides/en/acf-only.md
+++ b/guides/en/acf-only.md
@@ -1,237 +1,235 @@
 # Adobe ColdFusion only
 
-##The following tags/functions are Adobe ColdFusion only
-
-`cfexchangeconnection`
-
-`cfgrid` - Minimum Version: 3
-
-`cfprogressbar`
-
-`cfformgroup`
-
-`cfmenu`
-
-`isFileObject` - Minimum Version: 11
-
-`getSafeHTML` - Minimum Version: 11
-
-`cfexchangemail`
-
-`queryAppend` - Minimum Version: 2018.0.5
-
-`cfmenuitem`
-
-`cfexchangecontact`
-
-`cfwebsocket` - Minimum Version: 10
-
-`cfprint`
-
-`isPDFFile` - Minimum Version: 8
-
-`parameterExists`
-
-`cfsprydataset` - Minimum Version: 8
-
-`queryClear` - Minimum Version: 2018.0.5
-
-`wsSendMessage` - Minimum Version: 10
-
-`wsPublish` - Minimum Version: 10
-
-`imageMakeTranslucent` - Minimum Version: 10
-
-`cflayoutarea`
-
-`cflayout`
-
-`queryInsertAt` - Minimum Version: 2018
-
-`cfoauth` - Minimum Version: 11
-
-`arraySetMetadata` - Minimum Version: 2016.0.2
-
-`cfformitem`
-
-`isPDFArchive` - Minimum Version: 2016
-
-`spreadsheetSetRowHeight`
-
-`dotnetToCFType` - Minimum Version: 8
-
-`cfwindow`
-
-`cfexchangecalendar`
-
-`queryGetResult` - Minimum Version: 2016.3
-
-`listReduce` - Minimum Version: 11
-
-`cfmessagebox`
-
-`structToSorted` - Minimum Version: 2016.0.3
-
-`cfhtmltopdf` - Minimum Version: 11
-
-`cfgridrow` - Minimum Version: 3
-
-`encodeFor` - Minimum Version: 2016
-
-`verifySCryptHash` - Minimum Version: 2021
-
-`cfpresentationslide`
-
-`structGetMetadata` - Minimum Version: 2016.0.2
-
-`writeBody`
-
-`cfsharepoint`
-
-`cfgridcolumn` - Minimum Version: 3
-
-`verifyBCryptHash` - Minimum Version: 2021
-
-`cfclient` - Minimum Version: 11
-
-`cfpresentation`
-
-`deserialize` - Minimum Version: 11
+## The following tags/functions are Adobe ColdFusion only
 
 `arrayDeleteNoCase` - Minimum Version: 2016
 
-`wsGetAllChannels` - Minimum Version: 10
+`arrayGetMetadata` - Minimum Version: 2016.0.2
 
-`cfpdfform`
+`arrayReduceRight` - Minimum Version: 2021
 
-`imageGetMetadata` - Minimum Version: 11
+`arraySetMetadata` - Minimum Version: 2016.0.2
 
-`cfpod`
-
-`serializeXML` - Minimum Version: 11
-
-`ormIndexPurge` - Minimum Version: 10
-
-`isSpreadsheetFile`
-
-`cfpdfformparam`
-
-`spreadsheetAddAutoFilter` - Minimum Version: 11
+`arraySplice` - Minimum Version: 2018.0.5
 
 `cacheGetEngineProperties` - Minimum Version: 2018
 
-`spreadsheetAddPagebreaks` - Minimum Version: 11
-
-`cfntauthenticate` - Minimum Version: 4
-
 `cacheGetSession` - Minimum Version: 9.0.1
 
-`cfpresenter`
-
-`structSetMetadata` - Minimum Version: 2016.0.2
-
-`queryPrepend` - Minimum Version: 2018.0.5
+`cf_socialplugin` - Minimum Version: 11
 
 `cfcalendar`
 
+`cfclient` - Minimum Version: 11
+
+`cfclientsettings` - Minimum Version: 11
+
+`cfexchangecalendar`
+
+`cfexchangeconnection`
+
+`cfexchangecontact`
+
+`cfexchangefilter`
+
+`cfexchangemail`
+
+`cfexchangetask`
+
+`cffileupload`
+
+`cfformgroup`
+
+`cfformitem`
+
+`cfgrid` - Minimum Version: 3
+
+`cfgridcolumn` - Minimum Version: 3
+
+`cfgridrow` - Minimum Version: 3
+
+`cfgridupdate` - Minimum Version: 3
+
+`cfhtmltopdf` - Minimum Version: 11
+
+`cfhtmltopdfitem` - Minimum Version: 11
+
+`cfimapfilter` - Minimum Version: 11
+
+`cflayout`
+
+`cflayoutarea`
+
+`cfmap`
+
+`cfmapitem`
+
 `cfmediaplayer`
+
+`cfmenu`
+
+`cfmenuitem`
+
+`cfmessagebox`
+
+`cfntauthenticate` - Minimum Version: 4
+
+`cfoauth` - Minimum Version: 11
+
+`cfpdfform`
+
+`cfpdfformparam`
+
+`cfpdfsubform`
+
+`cfpod`
+
+`cfpresentation`
+
+`cfpresentationslide`
+
+`cfpresenter`
+
+`cfprint`
+
+`cfprogressbar`
+
+`cfreport` - Minimum Version: 2
+
+`cfreportparam`
+
+`cfservlet` - Minimum Version: 4.5
+
+`cfservletparam` - Minimum Version: 4.5
+
+`cfsharepoint`
+
+`cfsprydataset` - Minimum Version: 8
+
+`cftooltip`
+
+`cfwebsocket` - Minimum Version: 10
+
+`cfwindow`
+
+`deserialize` - Minimum Version: 11
+
+`deserializeXML` - Minimum Version: 11
+
+`dotnetToCFType` - Minimum Version: 8
+
+`encodeFor` - Minimum Version: 2016
+
+`generateBCryptHash` - Minimum Version: 2021
+
+`generateSCryptHash` - Minimum Version: 2021
+
+`getException`
+
+`getGatewayHelper`
+
+`getPrinterInfo`
+
+`getSafeHTML` - Minimum Version: 11
+
+`imageCreateCaptcha` - Minimum Version: 10
 
 `imageGetIPTCMetadata` - Minimum Version: 8
 
-`structIsOrdered` - Minimum Version: 2018
+`imageGetMetadata` - Minimum Version: 11
 
-`cfimapfilter` - Minimum Version: 11
+`imageMakeColorTransparent` - Minimum Version: 10
+
+`imageMakeTranslucent` - Minimum Version: 10
+
+`invalidateOauthAccesstoken` - Minimum Version: 11
+
+`isDDX`
+
+`isFileObject` - Minimum Version: 11
+
+`isPDFArchive` - Minimum Version: 2016
+
+`isPDFFile` - Minimum Version: 8
+
+`isSafeHTML` - Minimum Version: 11
+
+`isSpreadsheetFile`
+
+`isValidOauthAccesstoken` - Minimum Version: 11
+
+`listReduce` - Minimum Version: 11
+
+`listReduceRight` - Minimum Version: 2021
+
+`onServerStart` - Minimum Version: 9
+
+`ormFlushAll` - Minimum Version: 9.0.1
+
+`ormIndex` - Minimum Version: 10
+
+`ormIndexPurge` - Minimum Version: 10
+
+`ormSearch` - Minimum Version: 10
+
+`ormSearchOffline` - Minimum Version: 10
+
+`parameterExists`
+
+`queryAppend` - Minimum Version: 2018.0.5
+
+`queryClear` - Minimum Version: 2018.0.5
+
+`queryGetResult` - Minimum Version: 2016.3
+
+`queryInsertAt` - Minimum Version: 2018
+
+`queryPrepend` - Minimum Version: 2018.0.5
+
+`queryReverse` - Minimum Version: 2018.0.5
+
+`queryRowSwap` - Minimum Version: 2018
+
+`removeCachedQuery` - Minimum Version: 10
+
+`serializeXML` - Minimum Version: 11
+
+`sessionGetMetadata` - Minimum Version: 10
+
+`spreadsheetAddAutoFilter` - Minimum Version: 11
+
+`spreadsheetAddPagebreaks` - Minimum Version: 11
+
+`spreadsheetFormatCellRange` - Minimum Version: 9.0.1
 
 `spreadsheetGetColumnCount` - Minimum Version: 2016
 
 `spreadsheetRemoveSheet` - Minimum Version: 9.0.1
 
-`ormIndex` - Minimum Version: 10
-
-`cfreportparam`
-
-`getPrinterInfo`
-
-`queryReverse` - Minimum Version: 2018.0.5
-
-`isDDX`
-
-`ormSearchOffline` - Minimum Version: 10
-
-`cfmap`
-
-`cffileupload`
-
-`arrayGetMetadata` - Minimum Version: 2016.0.2
+`spreadsheetSetRowHeight`
 
 `stringReduceRight` - Minimum Version: 2021
 
-`cfservlet` - Minimum Version: 4.5
-
-`cfreport` - Minimum Version: 2
-
-`cfexchangefilter`
+`structGetMetadata` - Minimum Version: 2016.0.2
 
 `structIsCaseSensitive` - Minimum Version: 2021
 
-`spreadsheetFormatCellRange` - Minimum Version: 9.0.1
+`structIsOrdered` - Minimum Version: 2018
 
-`imageCreateCaptcha` - Minimum Version: 10
+`structSetMetadata` - Minimum Version: 2016.0.2
 
-`ormSearch` - Minimum Version: 10
+`structToSorted` - Minimum Version: 2016.0.3
 
-`removeCachedQuery` - Minimum Version: 10
+`verifyBCryptHash` - Minimum Version: 2021
 
-`cfexchangetask`
+`verifySCryptHash` - Minimum Version: 2021
 
-`arrayReduceRight` - Minimum Version: 2021
+`writeBody`
 
-`cfhtmltopdfitem` - Minimum Version: 11
-
-`arraySplice` - Minimum Version: 2018.0.5
-
-`cfservletparam` - Minimum Version: 4.5
-
-`getException`
-
-`cfpdfsubform`
-
-`cf_socialplugin` - Minimum Version: 11
-
-`cfgridupdate` - Minimum Version: 3
-
-`deserializeXML` - Minimum Version: 11
-
-`sessionGetMetadata` - Minimum Version: 10
-
-`replaceListNoCase` - Minimum Version: 2016
-
-`onServerStart` - Minimum Version: 9
-
-`isSafeHTML` - Minimum Version: 11
-
-`generateSCryptHash` - Minimum Version: 2021
-
-`imageMakeColorTransparent` - Minimum Version: 10
-
-`queryRowSwap` - Minimum Version: 2018
-
-`cftooltip`
-
-`ormFlushAll` - Minimum Version: 9.0.1
-
-`invalidateOauthAccesstoken` - Minimum Version: 11
-
-`listReduceRight` - Minimum Version: 2021
-
-`isValidOauthAccesstoken` - Minimum Version: 11
-
-`cfclientsettings` - Minimum Version: 11
-
-`generateBCryptHash` - Minimum Version: 2021
+`wsGetAllChannels` - Minimum Version: 10
 
 `wsGetSubscribers` - Minimum Version: 10
 
-`cfmapitem`
+`wsPublish` - Minimum Version: 10
 
-`getGatewayHelper`
+`wsSendMessage` - Minimum Version: 10

--- a/guides/en/deprecated.md
+++ b/guides/en/deprecated.md
@@ -1,91 +1,91 @@
 # Deprecated
 
-##The following tags/functions are deprecated
-
-`cfmenu` - Deprecated as of Adobe ColdFusion 2016
-
-`empty` - Deprecated as of Lucee 4.5
-
-`cftreeitem` - Deprecated as of Adobe ColdFusion 11
-
-`cftable` - Deprecated as of Adobe ColdFusion 2016
-
-`esapiDecode` - Deprecated as of Lucee 5
-
-`cfmenuitem` - Deprecated as of Adobe ColdFusion 2016
-
-`getMetricData` - Deprecated as of Lucee 4
-
-`getMetricData` - Deprecated as of Railo 0
-
-`isK2ServerOnline` - Deprecated as of Adobe ColdFusion 6.1
-
-`listTrim` - Deprecated as of Lucee 4
-
-`parameterExists` - Deprecated as of Adobe ColdFusion 6
-
-`cfsprydataset` - Deprecated as of Adobe ColdFusion 11
-
-`cacheRegionNew` - Deprecated as of Lucee 5
-
-`esapiEncode` - Deprecated as of Lucee 5
-
-`getK2ServerDocCountLimit` - Deprecated as of Adobe ColdFusion 6.1
-
-`cftree` - Deprecated as of Adobe ColdFusion 11
-
-`cacheSetProperties` - Deprecated as of Lucee 4.5
-
-`imageDrawImage` - Deprecated as of Lucee 5
-
-`createObject` - Deprecated as of Lucee 5
-
-`getTemplatePath` - Deprecated as of Adobe ColdFusion 6
-
-`getTemplatePath` - Deprecated as of Lucee 4.5
-
-`cfcalendar` - Deprecated as of Adobe ColdFusion 2016
-
-`cfmediaplayer` - Deprecated as of Adobe ColdFusion 2016
-
-`cacheRegionExists` - Deprecated as of Lucee 5
-
-`htmlEditFormat` - Deprecated as of Adobe ColdFusion 11
-
-`isK2ServerABroker` - Deprecated as of Adobe ColdFusion 6.1
-
-`hash40` - Deprecated as of Lucee 4.5
-
-`cffileupload` - Deprecated as of Adobe ColdFusion 2016
-
-`cftextinput` - Deprecated as of Adobe ColdFusion 7
-
-`cfservlet` - Deprecated as of Adobe ColdFusion 6
-
-`nowServer` - Deprecated as of Lucee 4.5
-
-`isK2ServerDocCountExceeded` - Deprecated as of Adobe ColdFusion 6.1
-
-`cfservletparam` - Deprecated as of Adobe ColdFusion 6
-
-`componentInfo` - Deprecated as of Lucee 4.5
-
-`cacheRegionRemove` - Deprecated as of Lucee 5
-
-`cfslider` - Deprecated as of Adobe ColdFusion 11
-
-`getLocale` - Deprecated as of Lucee 5
-
-`getLocaleLanguage` - Deprecated as of Lucee 5.0
-
-`cfapplet` - Deprecated as of Adobe ColdFusion 11
+## The following tags/functions are deprecated
 
 `cacheKeyExists` - Deprecated as of Lucee 4.5
 
+`cacheRegionExists` - Deprecated as of Lucee 5
+
+`cacheRegionNew` - Deprecated as of Lucee 5
+
+`cacheRegionRemove` - Deprecated as of Lucee 5
+
+`cacheSetProperties` - Deprecated as of Lucee 4.5
+
+`cfapplet` - Deprecated as of Adobe ColdFusion 11
+
+`cfcalendar` - Deprecated as of Adobe ColdFusion 2016
+
+`cffileupload` - Deprecated as of Adobe ColdFusion 2016
+
+`cfmediaplayer` - Deprecated as of Adobe ColdFusion 2016
+
+`cfmenu` - Deprecated as of Adobe ColdFusion 2016
+
+`cfmenuitem` - Deprecated as of Adobe ColdFusion 2016
+
+`cfservlet` - Deprecated as of Adobe ColdFusion 6
+
+`cfservletparam` - Deprecated as of Adobe ColdFusion 6
+
+`cfslider` - Deprecated as of Adobe ColdFusion 11
+
+`cfsprydataset` - Deprecated as of Adobe ColdFusion 11
+
+`cftable` - Deprecated as of Adobe ColdFusion 2016
+
+`cftextinput` - Deprecated as of Adobe ColdFusion 7
+
+`cftree` - Deprecated as of Adobe ColdFusion 11
+
+`cftreeitem` - Deprecated as of Adobe ColdFusion 11
+
+`componentInfo` - Deprecated as of Lucee 4.5
+
+`createObject` - Deprecated as of Lucee 5
+
+`empty` - Deprecated as of Lucee 4.5
+
+`esapiDecode` - Deprecated as of Lucee 5
+
+`esapiEncode` - Deprecated as of Lucee 5
+
+`getCurrentContext` - Deprecated as of Lucee 5
+
 `getK2ServerDocCount` - Deprecated as of Adobe ColdFusion 6.1
+
+`getK2ServerDocCountLimit` - Deprecated as of Adobe ColdFusion 6.1
+
+`getLocale` - Deprecated as of Lucee 5
 
 `getLocaleCountry` - Deprecated as of Lucee 5.0
 
 `getLocaleDisplayName` - Deprecated as of Lucee 5
 
-`getCurrentContext` - Deprecated as of Lucee 5
+`getLocaleLanguage` - Deprecated as of Lucee 5.0
+
+`getMetricData` - Deprecated as of Lucee 4
+
+`getMetricData` - Deprecated as of Railo 0
+
+`getTemplatePath` - Deprecated as of Adobe ColdFusion 6
+
+`getTemplatePath` - Deprecated as of Lucee 4.5
+
+`hash40` - Deprecated as of Lucee 4.5
+
+`htmlEditFormat` - Deprecated as of Adobe ColdFusion 11
+
+`imageDrawImage` - Deprecated as of Lucee 5
+
+`isK2ServerABroker` - Deprecated as of Adobe ColdFusion 6.1
+
+`isK2ServerDocCountExceeded` - Deprecated as of Adobe ColdFusion 6.1
+
+`isK2ServerOnline` - Deprecated as of Adobe ColdFusion 6.1
+
+`listTrim` - Deprecated as of Lucee 4
+
+`nowServer` - Deprecated as of Lucee 4.5
+
+`parameterExists` - Deprecated as of Adobe ColdFusion 6

--- a/guides/en/discouraged.md
+++ b/guides/en/discouraged.md
@@ -1,103 +1,14 @@
 # Discouraged
 
-##The following tags/functions are discouraged to use
-
-`cfgrid`
-
-The use of tags generating UI is generally discouraged by the CFML community. See: https://static.raymondcamden.com/cfuitherightway/cfgrid/index.html
-
-`cfprogressbar`
-
-The use of tags generating UI is generally discouraged by the CFML community. See: https://static.raymondcamden.com/cfuitherightway/cfprogressbar/index.html
-
-`cfmenu`
-
-The use of tags generating UI is generally discouraged by the CFML community. See: https://static.raymondcamden.com/cfuitherightway/cfmenu/index.html
-
-`cfusion_Decrypt`
-
-The use of this function is discouraged. It is an internal function, call decrypt(string,key,"cfmx_compat","hex") instead.
-
-`cftreeitem`
-
-The use of tags generating UI is generally discouraged by the CFML community. See: https://static.raymondcamden.com/cfuitherightway/cftree/index.html
-
-`cftable`
-
-The use of tags that generate client side UI code is generally discouraged by the CFML community. See: http://static.raymondcamden.com/cfuitherightway/cftable/index.html 
-
-`cfmenuitem`
-
-The use of tags generating UI is generally discouraged by the CFML community. See: https://static.raymondcamden.com/cfuitherightway/cfmenu/index.html
-
-`cflayoutarea`
-
-The use of tags generating UI is generally discouraged by the CFML community. See: http://static.raymondcamden.com/cfuitherightway/cfpod/index.html
-
-`cflayout`
-
-The use of tags generating UI is generally discouraged by the CFML community. See: http://static.raymondcamden.com/cfuitherightway/cfpod/index.html
-
-`xmlFormat`
-
-Adobe recommends using encodeForXML instead of xmlFormat.
-
-`setVariable`
-
-This function is no longer required in well-formed CFML pages
-
-`urlSessionFormat`
-
-Putting session identifiers in the URL may lead to session hijacking.
-
-`sizeOf`
-
-This function is in an early state. Do not use in production!
-
-`cfwindow`
-
-The use of tags generating UI is generally discouraged by the CFML community. See: https://static.raymondcamden.com/cfuitherightway/cfwindow/index.html
+## The following tags/functions are discouraged to use
 
 `array`
 
 Lucee recommends to use the inline array notation.
 
-`cfgridrow`
+`cfapplication`
 
-The use of tags generating UI is generally discouraged by the CFML community. See: https://static.raymondcamden.com/cfuitherightway/cfgrid/index.html
-
-`cftree`
-
-The use of tags generating UI is generally discouraged by the CFML community. See: https://static.raymondcamden.com/cfuitherightway/cftree/index.html
-
-`cfselect`
-
-The use of tags generating UI is generally discouraged by the CFML community. See: http://static.raymondcamden.com/cfuitherightway/cfpod/index.html
-
-`cfgridcolumn`
-
-The use of tags generating UI is generally discouraged by the CFML community. See: https://static.raymondcamden.com/cfuitherightway/cfgrid/index.html
-
-`cfpod`
-
-The use of tags generating UI is generally discouraged by the CFML community. See: http://static.raymondcamden.com/cfuitherightway/cfpod/index.html
-
-`lsParseEuroCurrency`
-
-Use LSParseCurrency instead
-
-`cfusion_Encrypt`
-
-The use of this function is discouraged. It is an internal function, call encrypt(string,key,"cfmx_compat","hex") instead.
-
-`cfmap`
-
-The use of tags generating UI is generally discouraged by the CFML community. See: https://static.raymondcamden.com/cfuitherightway/cfmap/index.html
-
-`iIf`
-
-Use the ternary operator CF9+ instead because it does not evaluate.
-Example ternary operator: `( (condition) ? valueIfTrue : valueIfFalse )`
+Use Application.cfc instead of Application.cfm files. The Application component provides better organization and additional features. Note that if you are using Application.cfm it should contain a cfapplication tag.
 
 `cfcol`
 
@@ -107,30 +18,119 @@ The use of tags that generate client side UI code is generally discouraged by th
 
 The use of tags generating UI is generally discouraged by the CFML community. See: https://static.raymondcamden.com/cfuitherightway/cfdiv/index.html
 
-`urlEncodedFormat`
+`cfgrid`
 
-The continued use of this function is discouraged. It is recommended that you use EncodeForURL for all new applications.
+The use of tags generating UI is generally discouraged by the CFML community. See: https://static.raymondcamden.com/cfuitherightway/cfgrid/index.html
 
-`cfapplication`
+`cfgridcolumn`
 
-Use Application.cfc instead of Application.cfm files. The Application component provides better organization and additional features. Note that if you are using Application.cfm it should contain a cfapplication tag.
+The use of tags generating UI is generally discouraged by the CFML community. See: https://static.raymondcamden.com/cfuitherightway/cfgrid/index.html
+
+`cfgridrow`
+
+The use of tags generating UI is generally discouraged by the CFML community. See: https://static.raymondcamden.com/cfuitherightway/cfgrid/index.html
 
 `cfgridupdate`
 
 The use of tags generating UI is generally discouraged by the CFML community. See: https://static.raymondcamden.com/cfuitherightway/cfgrid/index.html
 
-`preserveSingleQuotes`
+`cflayout`
 
-The use of preserveSingleQuotes often (but not always) results in code that will be vulnerable to SQL Injection. Use the cfqueryparam tag instead, and you will not need to worry about single quotes.
+The use of tags generating UI is generally discouraged by the CFML community. See: http://static.raymondcamden.com/cfuitherightway/cfpod/index.html
+
+`cflayoutarea`
+
+The use of tags generating UI is generally discouraged by the CFML community. See: http://static.raymondcamden.com/cfuitherightway/cfpod/index.html
+
+`cfmap`
+
+The use of tags generating UI is generally discouraged by the CFML community. See: https://static.raymondcamden.com/cfuitherightway/cfmap/index.html
+
+`cfmapitem`
+
+The use of tags generating UI is generally discouraged by the CFML community. See: https://static.raymondcamden.com/cfuitherightway/cfmap/index.html
+
+`cfmenu`
+
+The use of tags generating UI is generally discouraged by the CFML community. See: https://static.raymondcamden.com/cfuitherightway/cfmenu/index.html
+
+`cfmenuitem`
+
+The use of tags generating UI is generally discouraged by the CFML community. See: https://static.raymondcamden.com/cfuitherightway/cfmenu/index.html
+
+`cfpod`
+
+The use of tags generating UI is generally discouraged by the CFML community. See: http://static.raymondcamden.com/cfuitherightway/cfpod/index.html
+
+`cfprogressbar`
+
+The use of tags generating UI is generally discouraged by the CFML community. See: https://static.raymondcamden.com/cfuitherightway/cfprogressbar/index.html
+
+`cfselect`
+
+The use of tags generating UI is generally discouraged by the CFML community. See: http://static.raymondcamden.com/cfuitherightway/cfpod/index.html
+
+`cftable`
+
+The use of tags that generate client side UI code is generally discouraged by the CFML community. See: http://static.raymondcamden.com/cfuitherightway/cftable/index.html 
 
 `cftooltip`
 
 The use of tags generating UI is generally discouraged by the CFML community. See: https://static.raymondcamden.com/cfuitherightway/cftooltip/index.html
 
+`cftree`
+
+The use of tags generating UI is generally discouraged by the CFML community. See: https://static.raymondcamden.com/cfuitherightway/cftree/index.html
+
+`cftreeitem`
+
+The use of tags generating UI is generally discouraged by the CFML community. See: https://static.raymondcamden.com/cfuitherightway/cftree/index.html
+
+`cfusion_Decrypt`
+
+The use of this function is discouraged. It is an internal function, call decrypt(string,key,"cfmx_compat","hex") instead.
+
+`cfusion_Encrypt`
+
+The use of this function is discouraged. It is an internal function, call encrypt(string,key,"cfmx_compat","hex") instead.
+
+`cfwindow`
+
+The use of tags generating UI is generally discouraged by the CFML community. See: https://static.raymondcamden.com/cfuitherightway/cfwindow/index.html
+
 `evaluate`
 
 In almost all cases evaluate is unnecessary (use bracket notation instead). Use of evaluate can lead to performance and security issues.
 
-`cfmapitem`
+`iIf`
 
-The use of tags generating UI is generally discouraged by the CFML community. See: https://static.raymondcamden.com/cfuitherightway/cfmap/index.html
+Use the ternary operator CF9+ instead because it does not evaluate.
+Example ternary operator: `( (condition) ? valueIfTrue : valueIfFalse )`
+
+`lsParseEuroCurrency`
+
+Use LSParseCurrency instead
+
+`preserveSingleQuotes`
+
+The use of preserveSingleQuotes often (but not always) results in code that will be vulnerable to SQL Injection. Use the cfqueryparam tag instead, and you will not need to worry about single quotes.
+
+`setVariable`
+
+This function is no longer required in well-formed CFML pages
+
+`sizeOf`
+
+This function is in an early state. Do not use in production!
+
+`urlEncodedFormat`
+
+The continued use of this function is discouraged. It is recommended that you use EncodeForURL for all new applications.
+
+`urlSessionFormat`
+
+Putting session identifiers in the URL may lead to session hijacking.
+
+`xmlFormat`
+
+Adobe recommends using encodeForXML instead of xmlFormat.

--- a/guides/en/lucee-only.md
+++ b/guides/en/lucee-only.md
@@ -1,255 +1,255 @@
 # Lucee only
 
-##The following tags/functions are Lucee only
-
-`componentCacheClear`
-
-`listItemTrim`
-
-`getLuceeID`
-
-`entityNameArray`
-
-`cfusion_Decrypt`
-
-`empty`
-
-`imageFonts`
-
-`collectionEvery`
-
-`esapiDecode`
-
-`isNotMap`
-
-`queryColumnArray`
-
-`imageFilterCurves`
-
-`systemCacheClear`
-
-`structKeyTranslate`
-
-`echo`
-
-`pagePoolList`
-
-`listTrim`
-
-`createUniqueID`
-
-`extensionExists` - Minimum Version: 5.3
-
-`render` - Minimum Version: 5
-
-`contractPath`
-
-`cacheClear`
-
-`pagePoolClear`
-
-`collectionEach`
-
-`sizeOf`
-
-`arrayMid`
-
-`esapiEncode` - Minimum Version: 4.5
-
-`array`
-
-`query`
-
-`createGUID`
-
-`cfretry`
-
-`argon2CheckHash` - Minimum Version: 5.3.8
-
-`nullValue`
-
-`cacheGetAll`
-
-`generateArgon2Hash` - Minimum Version: 5.3.8
-
-`queryGetCell`
-
-`dayOfWeekShortAsString`
-
-`ctCacheClear`
-
-`arrayToStruct`
-
-`imageFilterWarpGrid`
-
-`listEvery`
-
-`compress`
-
-`systemOutput`
-
-`imageFormats`
-
-`imageFilterKernel`
-
-`htmlParse`
-
-`imageFilterColorMap`
-
-`webserviceNew` - Minimum Version: 5
-
-`cfwhile`
-
-`parseNumber`
-
-`cfadmin`
-
-`ucFirst`
-
-`getFunctionKeywords`
-
-`newLine`
-
-`cacheGetDefaultCacheName`
-
-`isIPInRange`
-
-`listAvg`
-
-`sessionstartTime`
-
-`urlEncode`
-
-`collectionMap`
-
-`getBuiltinFunction`
-
-`imageDrawImage` - Minimum Version: 4.5
-
-`componentCacheList`
-
-`cfstopwatch`
-
-`queryColumnExists`
-
-`collectionFilter`
-
-`getApplicationSettings`
-
-`imageSetDrawingAlpha`
+## The following tags/functions are Lucee only
 
 `applicationStartTime`
 
-`cfusion_Encrypt`
+`argon2CheckHash` - Minimum Version: 5.3.8
 
-`collectionSome`
-
-`arrayMedian`
-
-`entityNameList`
-
-`getTagData`
-
-`sslCertificateList`
-
-`isVideoFile`
-
-`soundEx`
-
-`bundleInfo` - Minimum Version: 5
-
-`imageFilter`
-
-`getTagList`
-
-`beat`
-
-`hash40`
-
-`getLocaleInfo` - Minimum Version: 5
-
-`ctCacheList`
-
-`nowServer`
-
-`cfpageencoding`
-
-`lsDayOfWeek`
-
-`queryRowData`
-
-`isEmpty`
-
-`extensionList` - Minimum Version: 5.3
-
-`arrayReverse`
-
-`isZipFile`
-
-`sslCertificateInstall`
-
-`manifestRead` - Minimum Version: 5
-
-`listCompact`
-
-`queryColumnData`
-
-`queryCurrentRow`
-
-`getVariable`
-
-`componentInfo`
-
-`getMemoryUsage`
-
-`queryColumnCount`
-
-`metaphone`
-
-`cacheDelete`
-
-`toNumeric`
-
-`getLocaleLanguage`
+`array`
 
 `arrayIndexExists`
 
-`extract`
+`arrayMedian`
 
 `arrayMerge`
 
-`listIndexExists`
+`arrayMid`
 
-`getFunctionData`
+`arrayReverse`
 
-`monthShortAsString`
+`arrayToStruct`
 
-`unserializeJava`
+`beat`
 
-`collectionReduce`
+`bundleInfo` - Minimum Version: 5
+
+`cacheClear`
 
 `cacheCount`
 
+`cacheDelete`
+
+`cacheGetAll`
+
+`cacheGetDefaultCacheName`
+
 `cacheKeyExists`
 
-`getClassPath`
+`cfadmin`
 
-`stringLen`
+`cfpageencoding`
 
-`getLocaleCountry`
-
-`trueFalseFormat`
-
-`lsWeek`
+`cfretry`
 
 `cfsleep`
 
-`queryColumnList`
+`cfstopwatch`
 
-`listSome`
+`cfusion_Decrypt`
 
-`millisecond`
+`cfusion_Encrypt`
+
+`cfwhile`
+
+`collectionEach`
+
+`collectionEvery`
+
+`collectionFilter`
+
+`collectionMap`
+
+`collectionReduce`
+
+`collectionSome`
+
+`componentCacheClear`
+
+`componentCacheList`
+
+`componentInfo`
+
+`compress`
+
+`contractPath`
+
+`createGUID`
+
+`createUniqueID`
+
+`ctCacheClear`
+
+`ctCacheList`
+
+`dayOfWeekShortAsString`
+
+`each`
+
+`echo`
+
+`empty`
+
+`entityNameArray`
+
+`entityNameList`
+
+`esapiDecode`
+
+`esapiEncode` - Minimum Version: 4.5
+
+`extensionExists` - Minimum Version: 5.3
+
+`extensionList` - Minimum Version: 5.3
+
+`extract`
+
+`generateArgon2Hash` - Minimum Version: 5.3.8
+
+`getApplicationSettings`
+
+`getBuiltinFunction`
+
+`getClassPath`
 
 `getCurrentContext`
 
-`each`
+`getFunctionData`
+
+`getFunctionKeywords`
+
+`getLocaleCountry`
+
+`getLocaleInfo` - Minimum Version: 5
+
+`getLocaleLanguage`
+
+`getLuceeID`
+
+`getMemoryUsage`
+
+`getTagData`
+
+`getTagList`
+
+`getVariable`
+
+`hash40`
+
+`htmlParse`
+
+`imageDrawImage` - Minimum Version: 4.5
+
+`imageFilter`
+
+`imageFilterColorMap`
+
+`imageFilterCurves`
+
+`imageFilterKernel`
+
+`imageFilterWarpGrid`
+
+`imageFonts`
+
+`imageFormats`
+
+`imageSetDrawingAlpha`
+
+`isEmpty`
+
+`isIPInRange`
+
+`isNotMap`
+
+`isVideoFile`
+
+`isZipFile`
+
+`listAvg`
+
+`listCompact`
+
+`listEvery`
+
+`listIndexExists`
+
+`listItemTrim`
+
+`listSome`
+
+`listTrim`
+
+`lsDayOfWeek`
+
+`lsWeek`
+
+`manifestRead` - Minimum Version: 5
+
+`metaphone`
+
+`millisecond`
+
+`monthShortAsString`
+
+`newLine`
+
+`nowServer`
+
+`nullValue`
+
+`pagePoolClear`
+
+`pagePoolList`
+
+`parseNumber`
+
+`query`
+
+`queryColumnArray`
+
+`queryColumnCount`
+
+`queryColumnData`
+
+`queryColumnExists`
+
+`queryColumnList`
+
+`queryCurrentRow`
+
+`queryGetCell`
+
+`queryRowData`
+
+`render` - Minimum Version: 5
+
+`sessionstartTime`
+
+`sizeOf`
+
+`soundEx`
+
+`sslCertificateInstall`
+
+`sslCertificateList`
+
+`stringLen`
+
+`structKeyTranslate`
+
+`systemCacheClear`
+
+`systemOutput`
+
+`toNumeric`
+
+`trueFalseFormat`
+
+`ucFirst`
+
+`unserializeJava`
+
+`urlEncode`
+
+`webserviceNew` - Minimum Version: 5

--- a/utilities/guide.cfm
+++ b/utilities/guide.cfm
@@ -17,7 +17,7 @@
 		writeOutput(
 			'## Discouraged'
 			& crlf & crlf
-			& '####The following tags/functions are discouraged to use'
+			& '#### The following tags/functions are discouraged to use'
 		);
 	}
 
@@ -26,7 +26,7 @@
 		writeOutput(
 			'## Deprecated'
 			& crlf & crlf
-			& '####The following tags/functions are deprecated'
+			& '#### The following tags/functions are deprecated'
 		);
 	}
 
@@ -35,7 +35,7 @@
 		writeOutput(
 			'## Adobe ColdFusion only'
 			& crlf & crlf
-			& '####The following tags/functions are Adobe ColdFusion only'
+			& '#### The following tags/functions are Adobe ColdFusion only'
 		);
 	}
 
@@ -44,12 +44,12 @@
 		writeOutput(
 			'## Lucee only'
 			& crlf & crlf
-			& '####The following tags/functions are Lucee only'
+			& '#### The following tags/functions are Lucee only'
 		);
 	}
 
 	/* loop all files from datadir */
-	for (file in directoryList(dataDir)) {
+	for (file in directoryList(path=dataDir, sort="Name")) {
 		dataStruct = deserializeJSON(fileRead(file));
 
 		/* get files with discouraged tags/functions and append them to the file */


### PR DESCRIPTION
The auto-generated guides "Adobe ColdFusion only", "Deprecated", "Discouraged", and "Lucee only" listed their tags/functions without a sensible order. They are now ordered alphabetically.

I've also added a space between the `##` and secondary heading as that is bad practice and seems to break the heading with flexmark.