### PR TITLE
Capitalize Examples subheading

### DIFF
--- a/views/doc.cfm
+++ b/views/doc.cfm
@@ -3,8 +3,8 @@
 		related = [];
 		guides = [];
 		if (structKeyExists(data, "related") AND arrayLen(data.related)) {
-			for(i = 1; i lte arrayLen(data.related); i++) {
-                		_doc = data.related[i];
+			for (i = 1; i lte arrayLen(data.related); i++) {
+				_doc = data.related[i];
 				jsonPath = expandPath("./data/en/#LCase(_doc)#.json");
 				guidePath = expandPath("./guides/en/#LCase(_doc)#.md");
 				if (fileExists(jsonPath)) {
@@ -29,7 +29,6 @@
 					<cfif data.type IS "function" AND StructKeyExists(data, "returns") AND Len(data.returns)>
 						<code><em>&##8594; returns #encodeForHTML(data.returns)#</em></code>
 					</cfif>
-					
 				</p>
 				<cfif data.type IS "tag">
 					<cfif StructKeyExists(data, "script")>
@@ -46,7 +45,7 @@
 					</cfif>
 				<cfelseif data.type is "function">
 					<cfif StructKeyExists(data, "member")>
-					 	<h4><em>Member Function Syntax</em></h4>
+						<h4><em>Member Function Syntax</em></h4>
 						<p id="member-syntax">
 							<code>#encodeForHTML(data.member)#</code>
 						</p>
@@ -98,7 +97,7 @@
 			<cfif data.type IS "tag" OR url.name contains "-tags"><li><a href="#linkTo("tags")#">Tags</a></li></cfif>
 			<cfset cat = findCategory(url.name)>
 			<cfif Len(cat)><li><a href="#linkTo(cat)#">#application.categories[cat].name#</a></li></cfif>
-			<li class="active">#data.name#</li>			
+			<li class="active">#data.name#</li>
 
 			<cfif StructKeyExists(data, "engines") AND StructKeyExists(data.engines, "coldfusion") AND StructKeyExists(data.engines.coldfusion, "docs") AND Len(data.engines.coldfusion.docs)>
 				<li class="pull-right">
@@ -119,7 +118,7 @@
 				<li role="separator" class="pull-right divider"></li>
 			</cfif>
 			<li class="pull-right">
-		    		<span class="label label-warning">
+				<span class="label label-warning">
 					<a href="https://github.com/foundeo/cfdocs/issues?q=is:issue%20is:open%20#encodeForURL(data.name)#" class="issuecount badge">0</a>
 					<a href="https://github.com/foundeo/cfdocs/issues/new?title=#encodeForURL(data.name)#" rel="nofollow" class="issuebutton" title="Report an Issue">Issue</a>
 				</span>
@@ -131,7 +130,7 @@
 			</cfif>
 		</ol>
 	</cfif>
-	
+
 	<div class="container">
 		<cfif arrayLen(related)>
 			<cfif data.type IS "listing" OR data.type IS "404">
@@ -174,7 +173,7 @@
 					<span class="item-name">#encodeForHTML(data.name)#</span>
 				</cfif>
 			</h2>
-			
+
 			<cfloop array="#data.params#" index="p">
 				<div class="param" id="p-#encodeForHTMLAttribute(p.name)#">
 					<h4>
@@ -185,8 +184,8 @@
 								<div class="p-default pull-right"><span class="text-muted">Default:</span> <code>#encodeForHTML(p.default)#</code></div>
 						</cfif>
 					</h4>
-					<div class="p-desc">						
-						#autoLink( p.description )# 
+					<div class="p-desc">
+						#autoLink( p.description )#
 						<cfif structKeyExists(p, "values") AND isArray(p.values) AND arrayLen(p.values)>
 							<cfif uCase(arrayToList(p.values)) IS NOT "YES,NO">
 								<div>
@@ -202,7 +201,7 @@
 						<cfif structKeyExists(p, "callback_params") AND isArray(p.callback_params) and not arrayIsEmpty(p.callback_params)>
 							<h4>Callback parameters:</h4>
 							<ul>
-								<cfloop array="#p.callback_params#" index="i">									
+								<cfloop array="#p.callback_params#" index="i">
 									<li>
 										<code>#encodeForHTML(i.name)#</code><cfif structKeyExists(i, 'required') AND Len(i.required)><span title="required">&##42;</span></cfif>&ensp;
 										<cfif structKeyExists(i, 'type') AND Len(i.type)>
@@ -214,7 +213,7 @@
 							</ul>
 						</cfif>
 					</div>
-				</div>			
+				</div>
 			</cfloop>
 		</cfif>
 
@@ -253,8 +252,8 @@
 				</cfif>
 			</cfloop>
 			<cfif Len(compatibilityData)>
-					<h2>Compatibility</h2>
-					#compatibilityData#
+				<h2>Compatibility</h2>
+				#compatibilityData#
 			</cfif>
 		</cfif>
 
@@ -268,13 +267,12 @@
 		</cfif>
 		<cfif StructKeyExists(request,'gitFilePath') and StructKeyExists(data, "type") and (data.type is "tag" or data.type is "function")>
 			<h2 id="examples">
-				Examples 
+				Examples
 				<button type="button" style="margin-left:5px" class="btn btn-primary" data-toggle="modal" data-target=".add-example-modal-lg"><span class="glyphicon glyphicon-plus"></span> Add An Example</button>
 				<div>
-					<small>sample code <cfif data.type IS "function">invoking<cfelse>using</cfif> the #data.name# <cfif data.type IS "tag">tag<cfelse>function</cfif></small>
+					<small>Sample code <cfif data.type IS "function">invoking<cfelse>using</cfif> the #data.name# <cfif data.type IS "tag">tag<cfelse>function</cfif></small>
 				</div>
 			</h2>
-			
 
 			<div class="modal fade add-example-modal-lg" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel">
 				<div class="modal-dialog modal-lg" role="document">
@@ -283,42 +281,40 @@
 						<button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
 						<h4 class="modal-title" id="gridSystemModalLabel">Add an Example for: #data.name#</h4>
 						<div>Use this form to create the Serialized JSON string needed to add an example into the docs.</div>
-						
-					  </div>
-					  <div class="modal-body">
+					</div>
+					<div class="modal-body">
 						<div class="row form">
 							<div class="col-md-7">
-						
 								<input type="text" id="example-form-title" class="form-control" value="" placeholder="Title">
-								<br> 
+								<br>
 								<input  type="text" id="example-form-description" class="form-control" value="" placeholder="Description">
-								<br> 
-					
+								<br>
+
 								<textarea  id="example-form-code" placeholder="Code" class="form-control" rows="8"></textarea>
 								<br>
-					
+
 								<input  type="text" id="example-form-result" class="form-control" value="" placeholder="Expected Result or Output of the Code Example">
-								<br> 
+								<br>
 								<select id="example-form-runnable" class="form-control">
 									<option value="0">No - Do not show Run Code Button</option>
 									<option value="1" selected="selected">Yes - Show Run Code Button</option>
 								</select>
 							</div>
-							
+
 							<div class="col-md-5">
 								<ol style="margin-left: -21px;">
-								<li>Copy the generated code below	</li>				
-								<li><a href="https://github.com/foundeo/cfdocs#request.gitFilePath#" target="_blank" rel="nofollow" class="label label-danger">Click Here to edit doc for: #data.name#</a></li>
-								<li> Update doc by adding the example in the examples section</li>
-								<li> Scroll to the bottom and click "Propose Change"</li>
-							</ol>
-								<textarea rows="14" id="example-form-output" class="form-control" ></textarea>
+									<li>Copy the generated code below	</li>
+									<li><a href="https://github.com/foundeo/cfdocs#request.gitFilePath#" target="_blank" rel="nofollow" class="label label-danger">Click Here to edit doc for: #data.name#</a></li>
+									<li> Update doc by adding the example in the examples section</li>
+									<li> Scroll to the bottom and click "Propose Change"</li>
+								</ol>
+								<textarea rows="14" id="example-form-output" class="form-control"></textarea>
 							</div>
-					</div>
+						</div>
 					</div>
 				</div>
 				</div>
-			</div>	
+			</div>
 		</cfif>
 		<cfif StructKeyExists(data, "examples") AND IsArray(data.examples) AND ArrayLen(data.examples)>
 			<cfset request.hasExamples = true>
@@ -372,8 +368,9 @@
 	<cfargument name="name" type="string" required="true">
 	<cfargument name="mode" type="string" required="true">
 	<cfargument name="syntax" type="string">
-	<cfset result = "">
-	
+
+	<cfset var result = "">
+
 	<cfif mode is "cf">
 		<cfset result = ReplaceNoCase(name, "cf", "") & ";">
 	<cfelseif mode is "other">


### PR DESCRIPTION
With #1497, I think the subheading for "Examples" would look better if capitalized.

As I was editing this page, I also found some spacing issues I fixed. I also `var` scoped `result` in `replaceScript`.