### PR TITLE
Fix example code in cleartimezone.json

### DIFF
--- a/data/en/cleartimezone.json
+++ b/data/en/cleartimezone.json
@@ -35,8 +35,8 @@
 	"examples": [{
 		"title": "Clear the timezone",
 		"description": "Set the timezone and then clear it.",
-		"code": "setTimeZone(\"CET\");\nwriteOutput(getTimeZone().timezone)&\"→ \");\nclearTimeZone();\nwriteOutput(getTimezoneInfo().timezone);",
-		"result": "Etc/UTC→ CET",
+		"code": "setTimeZone(\"CET\");\nwriteOutput(getTimezoneInfo().timezone & \"→ \");\nclearTimeZone();\nwriteOutput(getTimezoneInfo().timezone);",
+		"result": "CET→ Etc/UTC",
 		"runnable": true
 	}]
 }


### PR DESCRIPTION
The example code had some errors in it and would not run in Lucee. The expected result was also the wrong way around.