### PR TITLE
TryCF's "CF2018" engine appears to be offline

### DIFF
--- a/trycf.cfm
+++ b/trycf.cfm
@@ -1,6 +1,6 @@
 <cfparam name="url.name" default="rereplace">
 <cfparam name="url.index" default="1" type="numeric">
-<cfparam name="url.engine" default="acf2018" type="variablename">
+<cfparam name="url.engine" default="acf2021" type="variablename">
 <cfsilent>
     <cfset url.name = ReReplace(url.name, "[^a-zA-Z0-9_-]", "", "ALL")>
     <cfif FileExists(ExpandPath("./data/en/#url.name#.json"))>


### PR DESCRIPTION
The CF2018 engine (acf2018) hasn't been working on TryCF.com for a couple months now. I've reached out via contact form & social media, but haven't received any response and it continues to return the following error when outputting something as simple as `writeoutput(now());`:
```
There was an error parsing your code. This usually indicates a missing ; or another compile time syntax error. Check your syntax and try again.
```