### PR TITLE
fix member syntax

### DIFF
--- a/data/en/queryappend.json
+++ b/data/en/queryappend.json
@@ -2,7 +2,7 @@
 	"name":"queryAppend",
 	"type":"function",
 	"syntax":"queryAppend(query1, query2)",
-    "member":"qry.queryAppend(query2)",
+    "member":"qry.append(query2)",
 	"returns":"query",
 	"related":["queryPrepend"],
 	"description":" Adds a query to the end of the current query.",


### PR DESCRIPTION
Member usage was wrong and raised method not found error in both 2018 and 2021. Plain .append works fine and is blessedly consistent with other data type specific append methods.