### PR TITLE
Fix member function syntax

### DIFF
--- a/data/en/queryprepend.json
+++ b/data/en/queryprepend.json
@@ -2,7 +2,7 @@
 	"name":"queryPrepend",
 	"type":"function",
 	"syntax":"queryPrepend(query1, query2)",
-    "member":"qry.queryPrepend(query2)",
+    "member":"qry.prepend(query2)",
 	"returns":"query",
 	"related":["queryAppend"],
 	"description":" Adds a query to the beginning of the current query.",


### PR DESCRIPTION
Member usage was wrong and raised method not found error in both 2018 and 2021. Plain .prepend works fine.