### PR TITLE
Update date-and-time-functions.json

### DIFF
--- a/data/en/date-and-time-functions.json
+++ b/data/en/date-and-time-functions.json
@@ -1,6 +1,6 @@
 {
 	"name":"Date and Time Functions",
 	"type":"listing",
-	"related":["clearTimezone","createDate","createDateTime","createODBCDate","createODBCDateTime","createODBCTime","createTime","createTimespan","dateAdd","dateCompare","dateConvert","dateDiff","dateFormat","datePart","dateTimeFormat","day","dayOfWeek","dayOfWeekAsString","dayOfWeekShortAsString","dayOfYear","daysInMonth","daysInYear","firstDayOfMonth","getHTTPTimeString","getNumericDate","getTickCount","getTimezone","getTimezoneInfo","hour","isDate","isLeapYear","isNumericDate","LSDateFormat","LSDayOfWeek","LSIsDate","LSParseDateTime","LSTimeFormat","minute","month","monthAsString","monthShortAsString","now","parseDateTime","quarter","second","setTimezone","timeFormat","year"],
+	"related":["clearTimezone","createDate","createDateTime","createODBCDate","createODBCDateTime","createODBCTime","createTime","createTimespan","dateAdd","dateCompare","dateConvert","dateDiff","dateFormat","datePart","dateTimeFormat","day","dayOfWeek","dayOfWeekAsString","dayOfWeekShortAsString","dayOfYear","daysInMonth","daysInYear","firstDayOfMonth","getHTTPTimeString","getNumericDate","getTickCount","getTimezone","getTimezoneInfo","hour","isDate","isDateObject","isLeapYear","isNumericDate","LSDateFormat","LSDayOfWeek","LSIsDate","LSParseDateTime","LSTimeFormat","minute","month","monthAsString","monthShortAsString","now","parseDateTime","quarter","second","setDay","setHour","setMinute","setMonth","setSecond","setYear","setTimezone","timeFormat","week","year"],
 	"description":"A listing of CFML Date / Time Functions."
 }


### PR DESCRIPTION
Added isDateObject, setDay, setHour, setMinute, setMonth, setSecond, setYear, and week to the list of supported functions. Reference: https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-by-category/date-and-time-functions.html. Note: With the exceptions of "week", these functions are not yet in cfdocs.org