### PR TITLE
Update decision-functions.json

### DIFF
--- a/data/en/decision-functions.json
+++ b/data/en/decision-functions.json
@@ -1,6 +1,6 @@
 {
 	"name":"Decision Functions",
 	"type":"listing",
-	"related":["directoryExists","fileExists","fileIsEOF","iIf","isArray","isBinary","isBoolean","isCustomFunction","isDate","isDebugMode","isDDX","isDefined","isInstanceOf","isJSON","isLeapYear","isNumeric","isNumericDate","isObject","isNull","isPDFFile","isPDFObject","isQuery","isSafeHTML","isSimpleValue","isSoapRequest","isSpreadsheetFile","isSpreadsheetObject","isStruct","isUserInAnyRole","isUserInRole","isUserLoggedIn","isValid","isWDDX","isXML","isXmlAttribute","isXmlDoc","isXmlElem","isXmlNode","isXmlRoot","lsIsCurrency","lsIsDate","lsIsNumeric","structIsEmpty","structKeyExists","yesNoFormat"],
+	"related":["directoryExists","fileExists","fileIsEOF","iIf","isArray","isBinary","isBoolean","isClosure","isCustomFunction","isDate","isDateObject","isDebugMode","isDDX","isDefined","isFileObject","isInstanceOf","isIPv6","isJSON","isLeapYear","isLocalHost","isLeapYear","isNull","isNumeric","isNumericDate","isObject","isPDFArchive","isPDFFile","isPDFObject","isQuery","isSafeHTML","isSimpleValue","isSoapRequest","isSpreadsheetFile","isSpreadsheetObject","isStruct","isUserInAnyRole","isUserInRole","isUserLoggedIn","isValid","isWDDX","isXML","isXmlAttribute","isXmlDoc","isXmlElem","isXmlNode","isXmlRoot","lsIsCurrency","lsIsDate","lsIsNumeric","structIsEmpty","structKeyExists","yesNoFormat"],
 	"description":"A listing of CFML Decision Functions."
 }


### PR DESCRIPTION
Added isClosure, isDateObject, isFileObject, isIPv6, isLocalHost, isLeapYear, isPDFArchive to list of supported functions. Reference: https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-by-category/decision-functions.html. Note: the following function is not in cfdocs yet: isDateObject.  Also, moved isNull before isNumeric so it's listed in alphabetical order