### PR TITLE
Update listgetat.json

### DIFF
--- a/data/en/listgetat.json
+++ b/data/en/listgetat.json
@@ -8,7 +8,7 @@
 	"params": [
 		{"name":"list","description":"","required":true,"default":"","type":"string","values":[]},
 		{"name":"position","description":"","required":true,"default":"","type":"numeric","values":[]},
-		{"name":"delimiters","description":"","required":false,"default":",","type":"string","values":[]},
+		{"name":"delimiter","description":"","required":false,"default":",","type":"string","values":[]},
 		{"name":"includeEmptyValues","description":"","required":false,"default":"false","type":"boolean","values":[]}
 	],
 	"engines": {


### PR DESCRIPTION
Corrected argument name to delimiter. This can be checked by calling people = "Mick,,,,Keith,,,,Charlie,Ronnie,,,,,Bill"; WriteOutput( "The second item is: #ListGetAt( list = people, position = 2, delimiter="," )#" ); If called with "delimiters" param instead, it throws an error (tested on CF2018).