### PR TITLE
Fix cfimage captcha example.

### DIFF
--- a/data/en/cfimage.json
+++ b/data/en/cfimage.json
@@ -192,7 +192,7 @@
 			"code": "<cfimage action=\"border\" source=\"#sourceImage#\" size=5 color=\"red\" name=\"withborder\">", "runnable":false },
 
 		{ "title": "Captcha action", "description": "Generate a CAPTCHA style image using medium difficulty.",
-			"code": "<cfimage action=\"captcha\" text=\"Captcha!\" difficulty=\"medium\" fontSize=\"18\" fonts=\"Comic Sans MS,Times New Roman\">","runnable":false },
+			"code": "<cfimage action=\"captcha\" width=\"200\" height=\"50\" text=\"Captcha!\" difficulty=\"medium\" fontSize=\"18\" fonts=\"Comic Sans MS,Times New Roman\">","runnable":false },
 
 		{ "title": "Convert action", "description": "Convert an image to a different format (in this case PNG).",
 			"code": "<cfimage action=\"convert\" source=\"#sourceImage#\" destination=\"#expandPath( 'destination.png' )#\" overwrite=\"true\">","runnable":false },


### PR DESCRIPTION
The captcha sample code for cfimage was missing the required "width" and "height" attributes.