### PR TITLE
Added "result" attribute to cflock for Lucee

### DIFF
--- a/data/en/cflock.json
+++ b/data/en/cflock.json
@@ -10,7 +10,8 @@
 		{"name":"scope","description":"Lock scope. Mutually exclusive with the name attribute.\n Lock name. Only one request in the specified scope can\n execute the code within this tag (or within any other\n cflock tag with the same lock scope scope) at a time.","required":false,"default":"","type":"string","values":["Application","request","Server","Session"]},
 		{"name":"name","description":"Lock name. Mutually exclusive with the scope attribute.\n Only one request can execute the code within a cflock tag\n with a given name at a time. Cannot be an empty string.","required":false,"default":"","type":"string","values":[]},
 		{"name":"throwontimeout","description":"How timeout conditions are handled.","required":false,"default":true,"type":"boolean","values":[]},
-		{"name":"type","description":"readOnly: lets more than one request read shared data.\n exclusive: lets one request read or write shared data.","required":false,"default":"exclusive","type":"string","values":["readonly","exclusive"]}
+		{"name":"type","description":"readOnly: lets more than one request read shared data.\n exclusive: lets one request read or write shared data.","required":false,"default":"exclusive","type":"string","values":["readonly","exclusive"]},
+		{"name":"result","description":"Lucee4+ Specifies a name for the structure in which cflock returns the statusCode and ExecutionTime variables. Default variable is \"cflock\".","required":false,"default":"cflock","type":"string","values":[]}
 	],
 	"engines": {
 		"coldfusion": {"minimum_version":"4", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-tags/tags-j-l/cflock.html"},


### PR DESCRIPTION
Lucee has a result attribute for returning the statusCode and ExcecutionTime of the lock as a variable.