### PR TITLE
EntityLoadByPK() does not have a `unique` parameter in Lucee

### DIFF
--- a/data/en/entityloadbypk.json
+++ b/data/en/entityloadbypk.json
@@ -7,8 +7,7 @@
 	"description":"Loads and returns an array of objects for given primary key.\nUse this function to avoid specifying the required boolean parameter in `EntityLoad()`.",
 	"params": [
 		{"name":"entity","description":"Name of the entity to be loaded.","required":true,"default":"","type":"string","values":[]},
-		{"name":"id","description":"ID of the entity to be loaded.","required":true,"default":"","type":"string","values":[]},
-		{"name":"unique","description":"Lucee4.5+ Specify whether you expect multiple or just one record.\nIf set to `true`, the entity is returned.\nIf set to `false` an array is returned to support multiple entities.\nIf set to `true` but multiple entities would be returned an error will be thrown.","required":false,"default":"","type":"boolean","values":[]}
+		{"name":"id","description":"ID of the entity to be loaded.","required":true,"default":"","type":"string","values":[]}
 	],
 	"engines": {
 		"coldfusion": {"minimum_version":"9", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-e-g/entityloadbypk.html"},


### PR DESCRIPTION
This PR drops the `unique` attribute from the `EntityLoadByPK()` docs, since it hasn't existed in the Lucee source code since 2015.

Maybe this was 4.5 only? Or did it ever exist at all?

https://github.com/lucee/Lucee/blob/6.0/core/src/main/java/lucee/runtime/functions/orm/EntityLoadByPK.java#L11