### PR TITLE
Fix return type of writeOutput

### DIFF
--- a/data/en/writeoutput.json
+++ b/data/en/writeoutput.json
@@ -2,7 +2,7 @@
 	"name":"writeOutput",
 	"type":"function",
 	"syntax":"writeOutput(string)",
-	"returns":"string",
+	"returns":"boolean",
 	"related":["cfoutput","encodeForHTML"],
 	"description":" Appends text to the page-output stream.\n This function writes to the page-output stream regardless of\n conditions established by the cfsetting tag.",
 	"params": [


### PR DESCRIPTION
Noticed the return type for writeOutput was incorrect.  The Adobe docs don't even mention it but the Lucee docs are correct: https://docs.lucee.org/reference/functions/writeoutput.html

