### PR TITLE
Corrected isLeapYear example to pass a numeric year instead of a date…

### DIFF
--- a/data/en/isleapyear.json
+++ b/data/en/isleapyear.json
@@ -22,7 +22,7 @@
 		{
 			"title": "Is the current date in a leap year?",
 			"description": "",
-			"code": "date = now();\nisLeapYear = isLeapYear(date);\nwriteOutput(isLeapYear);",
+			"code": "date = now();\nisLeapYear = isLeapYear(year(date));\nwriteOutput(isLeapYear);",
 			"result": "",
 			"runnable":true
 		}


### PR DESCRIPTION
Both Lucee & Adobe want a year passed to the method, not a date object.