### PR TITLE
Use static date in example

### DIFF
--- a/data/en/daysinyear.json
+++ b/data/en/daysinyear.json
@@ -23,7 +23,7 @@
 		{
 			"title": "Simple example",
 			"description": "Uses the daysInYear function to determine the number of days in a year",
-			"code": "<cfset result = daysInYear(now())>\n<cfoutput>#result#</cfoutput>",
+			"code": "<cfset Date = CreateDate(2023, 06, 18)>\r\n<cfset result = daysInYear(Date)>\r\n<cfoutput>#result#</cfoutput>",
 			"result": "365"
 		},
 		{


### PR DESCRIPTION
The first example fails to match the expected result in a leap year, so I switched it to a static date on a non-leap year.