### PR TITLE
Update csrfverifytoken.json

### DIFF
--- a/data/en/csrfverifytoken.json
+++ b/data/en/csrfverifytoken.json
@@ -6,7 +6,7 @@
 	"related":["csrfGenerateToken"],
 	"description":"Validates the passed in token against the token stored in the session for a specific key. Used to help prevent Cross-Site Request Forgery (CSRF) attacks.",
 	"params": [
-		{"name":"token","description":"The passed in token that is to be validated against the token stored in the session. Only the first 40 characters of the passed in token are used to verify.","required":true,"default":"","type":"string","values":[]},
+		{"name":"token","description":"The passed in token that is to be validated against the token stored in the session. For Adobe Coldfusion, only the first 40 characters of the passed in token are used to verify.","required":true,"default":"","type":"string","values":[]},
 		{"name":"key","description":"The key against which the token was originally generated.","required":false,"default":"","type":"string","values":[]}
 	],
 	"engines": {

--- a/data/en/csrfverifytoken.json
+++ b/data/en/csrfverifytoken.json
@@ -6,7 +6,7 @@
 	"related":["csrfGenerateToken"],
 	"description":"Validates the passed in token against the token stored in the session for a specific key. Used to help prevent Cross-Site Request Forgery (CSRF) attacks.",
 	"params": [
-		{"name":"token","description":"The passed in token that is to be validated against the token stored in the session.","required":true,"default":"","type":"string","values":[]},
+		{"name":"token","description":"The passed in token that is to be validated against the token stored in the session. Only uses the first 40 characters of the passed in token.","required":true,"default":"","type":"string","values":[]},
 		{"name":"key","description":"The key against which the token was originally generated.","required":false,"default":"","type":"string","values":[]}
 	],
 	"engines": {

--- a/data/en/csrfverifytoken.json
+++ b/data/en/csrfverifytoken.json
@@ -6,7 +6,7 @@
 	"related":["csrfGenerateToken"],
 	"description":"Validates the passed in token against the token stored in the session for a specific key. Used to help prevent Cross-Site Request Forgery (CSRF) attacks.",
 	"params": [
-		{"name":"token","description":"The passed in token that is to be validated against the token stored in the session. Only uses the first 40 characters of the passed in token.","required":true,"default":"","type":"string","values":[]},
+		{"name":"token","description":"The passed in token that is to be validated against the token stored in the session. Only the first 40 characters of the passed in token are used to verify.","required":true,"default":"","type":"string","values":[]},
 		{"name":"key","description":"The key against which the token was originally generated.","required":false,"default":"","type":"string","values":[]}
 	],
 	"engines": {


### PR DESCRIPTION
csrfVerifyToken only checks the first 40 characters of the token passed in.

This should be included in the documentation as it means something like

csrfToken = 'ABC123ABCABC123ABCABC123ABCABC123ABCDEFG'&'123'

Will still verify if the generated token from generateCSRFToken is 'ABC123ABCABC123ABCABC123ABCABC123ABCDEFG'

![Screenshot 2024-07-11 at 2 32 44 PM](https://github.com/foundeo/cfdocs/assets/3860091/d10598fb-0ac9-4548-8479-93ccc565dcc4)
