### PR TITLE
Add script syntax hint for cfswitch

### DIFF
--- a/data/en/cfswitch.json
+++ b/data/en/cfswitch.json
@@ -2,6 +2,7 @@
 	"name":"cfswitch",
 	"type":"tag",
 	"syntax":"<cfswitch expression=\"\">",
+	"script":"switch (expression) { }",
 	"related":["cfcase","cfdefaultcase"],
 	"description":"Evaluates a passed expression and passes control to the cfcase tag that matches the expression result. You can, optionally, code a cfdefaultcase tag, which receives control if there is no matching cfcase tag value. Note the difference in the tag and script syntax when providing multiple values for a case.",
 	"params": [


### PR DESCRIPTION
This PR simply adds `switch (expression) { }` as the script syntax hint for [cfswitch](https://cfdocs.org/cfswitch). I figured specifying how `case`es are defined would probably be more cumbersome than practical — for that, looking at the already existing example should do.