### PR TITLE
Drop param from ormcloseallsessions.json, there is no param in ACF or Lucee

### DIFF
--- a/data/en/ormcloseallsessions.json
+++ b/data/en/ormcloseallsessions.json
@@ -5,9 +5,7 @@
 	"returns":"void",
 	"related":["ORMGetSession", "ORMClearSession", "ORMFlush", "ORMGetSessionFactory", "ORMCloseSession"],
 	"description":" Closes all Hibernate sessions in the request.",
-	"params": [
-		{"name":"region","description":"Name of the cache region.","required":true,"default":"","type":"string","values":[]}
-	],
+	"params": [],
 	"engines": {
 		"coldfusion": {"minimum_version":"9.0.1", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-m-r/ormcloseallsessions.html"},
 		"lucee": {"minimum_version":"", "notes":"", "docs":"https://docs.lucee.org/reference/functions/ormcloseallsessions.html"},


### PR DESCRIPTION
See ACF docs: https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-m-r/ormcloseallsessions.html

and Lucee docs: https://docs.lucee.org/reference/functions/ormcloseallsessions.html

It is clear this BIF does not take arguments.