### PR TITLE
var scope errors on Adobe ColdFusion in examples for querysome & structsome

### DIFF
--- a/data/en/querysome.json
+++ b/data/en/querysome.json
@@ -42,13 +42,13 @@
 		{
 			"title":" The simple Querysome example",
 			"description":"Here,we've example to check whether the 75 is exists or not in myquery mark column value.",
-			"code":"<cfscript>\r\n var myQuery = queryNew(\"id,name,mark\",\"integer,varchar,integer\",[[1,\"Rahu\",75],[2,\"Ravi\",80]]);\r\n result = querySome(myQuery , function(details){\r\n\t return details.mark IS 75;\r\n });\r\n writeOutput((result ? \"Some\" : \"No\") & \" matches  Record found!\");\r\n</cfscript>",
+			"code":"<cfscript>\r\nmyQuery = queryNew(\"id,name,mark\",\"integer,varchar,integer\",[[1,\"Rahu\",75],[2,\"Ravi\",80]]);\r\n result = querySome(myQuery , function(details){\r\n\t return details.mark IS 75;\r\n });\r\n writeOutput((result ? \"Some\" : \"No\") & \" matches  Record found!\");\r\n</cfscript>",
 			"result":"Some matches Record found!"
 		},
 		{
 			"title":"The Query Member Function example",
 			"description":"Here,we've example to check whether the 85 is exists or not in myquery mark column value using query member function.",
-			"code":"<cfscript>\r\n var myQuery = queryNew(\"id,name,mark\",\"integer,varchar,integer\",[[1,\"Rahu\",75],[2,\"Ravi\",80]]);\r\n result = myQuery.Some(function(details){\r\n\t return details.mark IS 85;\r\n });\r\n writeOutput((result ? \"Some\" : \"No\") & \" matches  Record found!\");\r\n</cfscript>",
+			"code":"<cfscript>\r\nmyQuery = queryNew(\"id,name,mark\",\"integer,varchar,integer\",[[1,\"Rahu\",75],[2,\"Ravi\",80]]);\r\n result = myQuery.Some(function(details){\r\n\t return details.mark IS 85;\r\n });\r\n writeOutput((result ? \"Some\" : \"No\") & \" matches  Record found!\");\r\n</cfscript>",
 			"result":"No matches Record found!"
 		}
 	],

--- a/data/en/structsome.json
+++ b/data/en/structsome.json
@@ -42,13 +42,13 @@
 		{
 			"title":"The simple StructSome example",
 			"description":"Here we have simple example about structsome function.",
-			"code":"<cfscript>\r\nvar struct={\"Name\":\"Raja\",\"age\":20,\"mark\":80};\r\nresult = structSome(struct,function(key,value){\r\n\treturn key IS \"Name\"\r\n});\r\nwriteOutput((result ? '' : 'No')& \" Key Exists.\")\r\n</cfscript>",
+			"code":"<cfscript>\r\nstruct={\"Name\":\"Raja\",\"age\":20,\"mark\":80};\r\nresult = structSome(struct,function(key,value){\r\n\treturn key IS \"Name\"\r\n});\r\nwriteOutput((result ? '' : 'No')& \" Key Exists.\")\r\n</cfscript>",
 			"result":"Key Exists."
 		},
 		{
 			"title":"The structSome member function example",
 			"description":"Here we have simple example about structsome as member function.",
-			"code":"<cfscript>\r\nvar struct={\"Name\":\"Raja\",\"age\":20,\"mark\":80};\r\nresult = struct.some(function(key,value){\r\n\treturn key IS \"average\"\r\n});\r\nwriteOutput((result ? '' : 'No')&\" Key Exists.\")\r\n</cfscript>",
+			"code":"<cfscript>\r\nstruct={\"Name\":\"Raja\",\"age\":20,\"mark\":80};\r\nresult = struct.some(function(key,value){\r\n\treturn key IS \"average\"\r\n});\r\nwriteOutput((result ? '' : 'No')&\" Key Exists.\")\r\n</cfscript>",
 			"result":"No Key Exists."
 		}
 	],


### PR DESCRIPTION
The code examples in the documentation for 

querysome (https://cfdocs.org/querysome) and 
structsome (https://cfdocs.org/structsome) utilise var scoping that causes execution failures in the default Adobe ColdFusion engine when the "Run Code" button is clicked.  My solution ensures compatibility with both CFML and Lucee.

Issue: 
![image](https://github.com/user-attachments/assets/690959b2-d99d-4944-8d27-637d53641ffa)
