### PR TITLE
surface search on narrow screens

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -62,6 +62,7 @@ $(document).ready(function() {
 	  });
 	  $('.tt-hint').addClass('form-control');
 	  $('#search').submit(submitSearch);
+	  $('#search2').submit(submitSearch);
 	  $('#lookup-box').on('typeahead:selected', submitSearch);
 	  $('#lookup-box').focus();
 
@@ -150,7 +151,7 @@ function fallbackCopyTextToClipboard(text) {
 //search submit
 function submitSearch(e) {
 	e.preventDefault();
-	var newLocation = $('#lookup-box').val().toLowerCase();
+	var newLocation = $(this).find('#lookup-box').val().toLowerCase();
 	document.location = '/' + encodeURIComponent((newLocation.length && newLocation[0] == '/') ? newLocation.slice(1) : newLocation);
 }
 //google analytics

--- a/views/index.cfm
+++ b/views/index.cfm
@@ -8,6 +8,16 @@ qPeople = oLeader.get();
   <div class="container">
     <h1>CFDocs</h1>
     <p>UltraFast CFML Documentation Reference.</p>
+    <form class="hidden-md hidden-lg" id="search2">
+      <div class="form-group">
+        <div class="input-group">
+          <input type="text" style="width:100%" placeholder="Tag or Function..." id="lookup-box" class="form-control">
+          <div class="input-group-btn">
+            <button type="submit" class="btn btn-primary" style="    margin-top: -4px;">Go</button>
+          </div>
+        </div>
+      </div>
+    </form>
   </div>
 </div>
 
@@ -50,7 +60,7 @@ qPeople = oLeader.get();
     </cfloop>
     <!--- cache for 1 day --->
     <cfset request.cacheControlMaxAge = 86400>
-  
+
     </cfoutput>
     </div>
   <cfelse>

--- a/views/layout.cfm
+++ b/views/layout.cfm
@@ -25,7 +25,7 @@
 		<meta property="og:image:alt" content="#EncodeForHTMLAttribute(request.description)#" />
 		<meta property="og:image:width" content="512" />
 		<meta property="og:image:height" content="256" />
-		
+
 		<meta name="twitter:image:src" content="https://cfdocs.org/openimage.cfm?name=#EncodeForHTMLAttribute(lcase(request.ogname))#" />
 		<meta name="twitter:site" content="CF Docs" />
 		<meta name="twitter:card" content="summary_large_image" />
@@ -103,7 +103,7 @@
 					</li>
 				</cfoutput>
 				</ul>
-				<form class="navbar-form navbar-left hidden-sm" id="search">
+				<form class="navbar-form navbar-left hidden-sm hidden-xs" id="search">
 					<div class="form-group">
 						<div class="input-group">
 							<input type="text" style="width:100%" placeholder="Tag or Function..." id="lookup-box" class="form-control">
@@ -118,7 +118,6 @@
 		</div>
 	</nav>
 
-	
 	<cfoutput>#request.content#</cfoutput>
 
 	<div class="jumbotron" id="cfbreak">
@@ -134,7 +133,7 @@
 				</div>
 		  </form>
 		</div>
-	</div>	
+	</div>
 
 
 	<footer>


### PR DESCRIPTION
> [!CAUTION]
> I was not able to get cfdocs running locally, so I have not been able to test these changes. However, they are small and I believe they should work. I did experiment with browser devtools to verify approaches.

The CFDocs site is responsive, which is great. But I would imagine that the majority use-case is to use the search, and when visiting on a narrow screen the search is hidden away inside the hamburger menu.

This change would -- only on narrow screens -- hide the form that collapses into the hamburger menu, and display a copy of the search form just underneath the site masthead.