### PR TITLE
Deprecation Cleanup: Mark Removed Features for ColdFusion 2025

### DIFF
--- a/data/en/cfhttp.json
+++ b/data/en/cfhttp.json
@@ -55,7 +55,7 @@
 			"result":""
 		},
 		{
-			"title": "Alternate Script Syntax (CF9+)",
+			"title": "Alternate Script Syntax (CF9+). Removed in ColdFusion 2025.",
 			"description": "",
 			"code": "httpService = new http(method = \"GET\", charset = \"utf-8\", url = \"https://www.google.com/\");\r\nhttpService.addParam(name = \"q\", type = \"url\", value = \"cfml\");\r\nresult = httpService.send().getPrefix();\r\nwriteDump(result);",
 			"result": ""

--- a/data/en/cfhttpparam.json
+++ b/data/en/cfhttpparam.json
@@ -27,7 +27,7 @@
 			"result":""
 		},
 		{
-			"title": "Alternate Script Syntax (CF9+)",
+			"title": "Alternate Script Syntax (CF9+). Removed in ColdFusion 2025.",
 			"description": "",
 			"code": "httpService = new http(method = \"POST\", charset = \"utf-8\", url = \"https://www.google.com/\");\r\nhttpService.addParam(name = \"q\", type = \"formfield\", value = \"cfml\");\r\nresult = httpService.send().getPrefix();\r\nwriteDump(result);",
 			"result": ""

--- a/data/en/cfmail.json
+++ b/data/en/cfmail.json
@@ -390,7 +390,7 @@
 			"code": "<cfset myQuery = queryNew( \"recipient,lastname,firstname\" )>\n<cfset queryAddRow( myQuery, { recipient = \"recipient@example.com\", lastname = \"Doe\", firstname = \"John\" }) />\n\n<cfmail to=\"#recipient#\" from=\"sender@example.com\" subject=\"Example email\" query=\"myQuery\">\n  Dear #lastname#,\n\n  Text here, containing any variable in the myQuery scope.\n</cfmail>"
 		},
 		{
-			"title": "Script syntax using new mail()",
+			"title": "Script syntax using new mail(). Removed in ColdFusion 2025.",
 			"description": "CF9+ The cfmail features are also available through the mail component.",
 			"code": "savecontent variable=\"mailBody\" {\n  writeOutput( \"Your Email Message!!\" );\n};\n\n// Create and populate the mail object\nmailService = new mail(\n  to = \"recipient@example.com\",\n  from = \"sender@example.com\",\n  subject = \"Example email\",\n  body = mailBody\n);\n\n// Send\nmailService.send();"
 		},

--- a/data/en/cfquery.json
+++ b/data/en/cfquery.json
@@ -63,7 +63,7 @@
 		},
 		{
 			"title": "Script Syntax using new Query()",
-			"description": "This syntax was implemented by script-based components in CF 9 & 10. It is superseded by queryExecute() in CF11.",
+			"description": "This syntax was implemented by script-based components in CF 9 & 10. Deprecated in ColdFusion 2018. Removed in ColdFusion 2025. It is superseded by queryExecute() in CF11.",
 			"code": "queryObj = new Query(\r\n name=\"qryDemo\",\r\n datasource=\"mydatasourcename\",\r\n sql = \"SELECT col1, col2\r\n FROM myTable\r\n WHERE id=:id\"\r\n); \r\nqueryObj.addParam(name=\"id\",value=arguments.id, cfsqltype=\"cf_sql_integer\");\r\nresultset=queryObj.execute().getResult();",
 			"result": ""
 		},

--- a/data/en/htmleditformat.json
+++ b/data/en/htmleditformat.json
@@ -25,7 +25,7 @@
 
   "engines": {
     "coldfusion": { "docs": "https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-h-im/htmleditformat.html",
-      "minimum_version": "", "notes": "Use encodeForHTML, which can provide more protection from XSS.", "deprecated" : "11" },
+      "minimum_version": "", "notes": "Use encodeForHTML, which can provide more protection from XSS.", "deprecated" : "11" , "removed":"2025"},
     "lucee":      { "docs": "https://docs.lucee.org/reference/functions/htmleditformat.html",
       "minimum_version": "", "notes": "" },
     "openbd":     { "docs": "http://openbd.org/manual/?/function/htmleditformat",

--- a/data/en/parameterexists.json
+++ b/data/en/parameterexists.json
@@ -9,7 +9,7 @@
 		{"name":"parameter","description":"A syntactically valid parameter name.","required":true,"default":"","type":"string","values":[]}
 	],
 	"engines": {
-		"coldfusion": {"minimum_version":"", "notes":"This function is deprecated, but is still available for backward compatibility. Use StructKeyExists() or IsDefined() functions instead.", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-m-r/parameterexists.html", "deprecated":"6"}
+		"coldfusion": {"minimum_version":"", "notes":"This function is deprecated, but is still available for backward compatibility until ColdFusion 2025. Use StructKeyExists() or IsDefined() functions instead.", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-m-r/parameterexists.html", "deprecated":"6", "removed":"2025"}
 	},
 	"links": [
 


### PR DESCRIPTION
This PR fixes #1704 by updating ColdFusion Docs to reflect features and syntax removed in ColdFusion 2025. Key changes include:
	•	Annotated alternate script syntax for http, cfmail, cfquery, and cfhttpparam as removed in CF2025
	•	Updated parameterExists() and htmlEditFormat() function metadata with removed: "2025" flags
	•	Clarified deprecation and replacement guidance where appropriate (e.g., queryExecute() for new Query())

These updates help future-proof documentation and guide developers away from deprecated features.