### PR TITLE
queryrowdata.json - change calls in examples

### DIFF
--- a/data/en/queryrowdata.json
+++ b/data/en/queryrowdata.json
@@ -16,15 +16,15 @@
 	},
 	"examples": [
 		{
-			"title":"The simple queryGetRow example",
+			"title":"The simple queryRowData example",
 			"description":"Here we've a example to get the particular row value from myquery.",
-			"code":"<cfset myQuery = queryNew(\"id,name,age\",\"integer,varchar,integer\",[[1,\"Dharshini\",20],[2,\"Subash\",18]])>\r\n<cfdump var=\"#queryGetRow(myQuery,2)#\" />",
+			"code":"<cfset myQuery = queryNew(\"id,name,age\",\"integer,varchar,integer\",[[1,\"Dharshini\",20],[2,\"Subash\",18]])>\r\n<cfdump var=\"#queryRowData(myQuery,2)#\" />",
 			"result":""
 		},
 		{
-			"title":"The simple getRow example",
+			"title":"The simple rowData example",
 			"description":"We've example to get the particular row value from myquery using script syntax.",
-			"code":"<cfscript>\r\nvar myQuery = queryNew(\"id,title,author\",\"integer,varchar,varchar\",[[1,\"Charlottes Web\",\"E.B. White\"],[3,\"The Outsiders\",\"S.E. Hinton\"],[4,\"Mieko and the Fifth Treasure\",\"Eleanor Coerr\"]]);\r\nwriteDump(myQuery.getRow(3));\r\n</cfscript>",
+			"code":"<cfscript>\r\nvar myQuery = queryNew(\"id,title,author\",\"integer,varchar,varchar\",[[1,\"Charlottes Web\",\"E.B. White\"],[3,\"The Outsiders\",\"S.E. Hinton\"],[4,\"Mieko and the Fifth Treasure\",\"Eleanor Coerr\"]]);\r\nwriteDump(myQuery.rowData(3));\r\n</cfscript>",
 			"result":""
 		}
 	],


### PR DESCRIPTION
In the examples instead of queryRowData() and rowData()  queryGetRow() and getRow() where used.