### PR TITLE
Change title of example `Application.cfc` guide to disambiguate the "Guides" dropdown

### DIFF
--- a/guides/en/application.md
+++ b/guides/en/application.md
@@ -1,4 +1,4 @@
-# Application.cfc
+# Example Application.cfc
 
 ## Example: Full Application/Request Lifecycle Methods
 


### PR DESCRIPTION
The "Guides" dropdown currently has two items named "Application.cfc" (https://cfdocs.org/application and https://cfdocs.org/application%2Dcfc) — this is an attempt to disambiguate that dropdown list.

I'm assuming that changing the title in `guides/en/application.md ` will update the name used in the "Guides" dropdown too.