### PR TITLE
Update `nullvalue.json`

### DIFF
--- a/data/en/nullvalue.json
+++ b/data/en/nullvalue.json
@@ -11,10 +11,16 @@
 		"boxlang": {"minimum_version":"1.0.0", "notes":"", "docs":"https://boxlang.ortusbooks.com/boxlang-language/reference/built-in-functions/type/nullvalue"}
 	},
 	"examples": [{
+            "title":"Example using nullvalue",
+            "description":"",
+            "code":"isNull(nullValue())",
+            "result":true,
+            "runnable":true
+        },{
             "title":"ColdFusion polyfill",
             "description":"Using java data type null instead",
-            "code":"writeOutput(isNull(nullValue()));",
-            "result":"YES",
+            "code":"isNull(javaCast('null', ''))",
+            "result":true,
             "runnable":true
         }],
 	"links": []


### PR DESCRIPTION
Updates the title of the existing example; re-adds the ColdFusion polyfill example removed in #1346 as a secondary example.