### PR TITLE
Add 'removed' field for 2025 to deprecated tags/functions

### DIFF
--- a/data/en/cfapplet.json
+++ b/data/en/cfapplet.json
@@ -75,7 +75,8 @@
 			"minimum_version": "",
 			"notes": "",
 			"docs": "https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-tags/tags-a-b/cfapplet.html",
-			"deprecated":"11"
+			"deprecated":"11",
+			"removed":"2025"
 		},
 		"lucee": {
 			"minimum_version": "",

--- a/data/en/cfmediaplayer.json
+++ b/data/en/cfmediaplayer.json
@@ -147,7 +147,8 @@
 			"minimum_version": "9",
 			"notes": "",
 			"docs": "https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-tags/tags-m-o/cfmediaplayer.html",
-			"deprecated":"2016"
+			"deprecated":"2016",
+			"removed":"2025"
 		}
 	},
 	"links": []

--- a/data/en/cfmenuitem.json
+++ b/data/en/cfmenuitem.json
@@ -80,7 +80,7 @@
 		}
 	],
 	"engines": {
-		"coldfusion": { "minimum_version": "8", "notes": "", "deprecated":"2016", "docs": "https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-tags/tags-m-o/cfmenuitem.html" }
+		"coldfusion": { "minimum_version": "8", "notes": "", "deprecated":"2016", "removed":"2025", "docs": "https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-tags/tags-m-o/cfmenuitem.html" }
 	},
 	"links": [],
 	"examples": [

--- a/data/en/cftable.json
+++ b/data/en/cftable.json
@@ -17,7 +17,7 @@
 
 	],
 	"engines": {
-		"coldfusion": {"minimum_version":"", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-tags/tags-t/cftable.html", "deprecated":"2016"},
+		"coldfusion": {"minimum_version":"", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-tags/tags-t/cftable.html", "deprecated":"2016", "removed":"2025"},
 		"lucee": {"minimum_version":"", "notes":"", "docs":"https://docs.lucee.org/reference/tags/table.html"},
 		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/tag/cftable"},
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/tag/cftable"}

--- a/data/en/cftreeitem.json
+++ b/data/en/cftreeitem.json
@@ -104,7 +104,7 @@
 		}
 	],
 	"engines": {
-		"coldfusion": { "minimum_version": "3", "deprecated":"11", "notes": "", "docs": "https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-tags/tags-t/cftreeitem.html" },
+		"coldfusion": { "minimum_version": "3", "deprecated":"11", "removed":"2025", "notes": "", "docs": "https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-tags/tags-t/cftreeitem.html" },
 		"openbd": { "minimum_version": "", "notes": "", "docs": "http://openbd.org/manual/?/tag/cftreeitem" }
 	},
 	"links": []

--- a/data/en/gettemplatepath.json
+++ b/data/en/gettemplatepath.json
@@ -7,7 +7,7 @@
 	"description":"Returns the filepath of the base template in this request",
 	"params": [],
 	"engines": {
-		"coldfusion": {"minimum_version":"", "notes":"Use the GetBaseTemplatePath function instead", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-e-g/gettemplatepath.html", "deprecated":"6"},
+		"coldfusion": {"minimum_version":"", "notes":"Use the GetBaseTemplatePath function instead", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-e-g/gettemplatepath.html", "deprecated":"6", "removed":"2025"},
 		"lucee": {"minimum_version":"", "notes":"Use the GetBaseTemplatePath function instead", "docs":"https://docs.lucee.org/reference/functions/gettemplatepath.html","deprecated":"4.5"},
 		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/function/gettemplatepath"},
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/function/gettemplatepath"}


### PR DESCRIPTION
Added a 'removed':'2025' field to the ColdFusion engine metadata for cfapplet, cfmediaplayer, cfmenuitem, cftable, cftreeitem, and gettemplatepath to indicate their planned removal in 2025. This provides clearer deprecation and removal timelines for these tags and functions.