### PR TITLE
Added default CFSSqlType -- CF_SQL_CHAR

### DIFF
--- a/data/en/cfqueryparam.json
+++ b/data/en/cfqueryparam.json
@@ -19,7 +19,7 @@
       "name": "cfsqltype",
       "description": "SQL type that parameter (any type) is bound to. As of CF11+ or Lucee4.5+ you can omit the `cf_sql_` prefix. \nSee [CFSqlType Cheatsheet](https://cfdocs.org/cfsqltype-cheatsheet) for a mapping of CFSQL data types to DBMS data types.",
       "required": false,
-      "default": "",
+      "default": "CF_SQL_CHAR",
       "type": "string",
       "values": [
         "cf_sql_bigint",


### PR DESCRIPTION
CFSqlType was missing the default value and leading to the possible impression that it was a required field (despite correctly noting that  it's not.)