### PR TITLE
Document ColdFusion tag deprecations and removals

### DIFF
--- a/data/en/cfchart.json
+++ b/data/en/cfchart.json
@@ -5,7 +5,7 @@
 	"related":["cfchartseries","cfchartdata"],
 	"description":"Generates and displays a chart.",
 	"params": [
-		{"name":"format","description":"File format in which to save graph.\n`format=flash` has been deprecated in CF2016+\nFor Lucee the default value is `png` and the format `html` is not supported.","required":false,"default":"html","type":"string","values":["html","flash","jpg","png"]},
+		{"name":"format","description":"File format in which to save graph.\n`format=flash` has been deprecated in CF2016+ and removed in CF2025\nFor Lucee the default value is `png` and the format `html` is not supported.","required":false,"default":"html","type":"string","values":["html","flash","jpg","png"]},
 		{"name":"chartheight","description":"Chart height; integer number of pixels","required":false,"default":240,"type":"numeric","values":[]},
 		{"name":"chartwidth","description":"Chart width; integer number of pixels","required":false,"default":320,"type":"numeric","values":[]},
 		{"name":"scalefrom","description":"Y-axis minimum value; integer","required":false,"default":"","type":"numeric","values":[]},

--- a/data/en/cfcol.json
+++ b/data/en/cfcol.json
@@ -12,7 +12,7 @@
 		{"name":"text","description":"Double-quotation mark-delimited text; determines what to\n display. Rules: same as for cfoutput sections. You can\n embed hyperlinks, image references, and input controls","required":true,"default":"","type":"string","values":[]}
 	],
 	"engines": {
-		"coldfusion": {"minimum_version":"", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-tags/tags-c/cfcol.html"},
+		"coldfusion": {"minimum_version":"", "notes":"", "deprecated":"2016", "removed":"2025", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-tags/tags-c/cfcol.html"},
 		"lucee": {"minimum_version":"", "notes":"", "docs":"https://docs.lucee.org/reference/tags/col.html"},
 		"railo": {"minimum_version":"", "notes":"", "docs":"http://railodocs.org/index.cfm/tag/cfcol"},
 		"openbd": {"minimum_version":"", "notes":"", "docs":"http://openbd.org/manual/?/tag/cfcol"}

--- a/data/en/cfformgroup.json
+++ b/data/en/cfformgroup.json
@@ -119,7 +119,7 @@
 		}
 	],
 	"engines": {
-		"coldfusion": { "minimum_version": "7", "notes": "", "docs": "https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-tags/tags-f/cfformgroup.html" }
+		"coldfusion": { "minimum_version": "7", "notes": "", "deprecated":"2016", "removed":"2025", "docs": "https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-tags/tags-f/cfformgroup.html" }
 	},
 	"links": []
 }

--- a/data/en/cfformitem.json
+++ b/data/en/cfformitem.json
@@ -71,7 +71,7 @@
 		}
 	],
 	"engines": {
-		"coldfusion": { "minimum_version": "7", "notes": "", "docs": "https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-tags/tags-f/cfformitem.html" }
+		"coldfusion": { "minimum_version": "7", "notes": "", "deprecated":"2016", "removed":"2025", "docs": "https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-tags/tags-f/cfformitem.html" }
 	},
 	"links": []
 }

--- a/data/en/cfsprydataset.json
+++ b/data/en/cfsprydataset.json
@@ -59,7 +59,8 @@
 			"minimum_version": "8",
 			"notes": "",
 			"docs": "https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-tags/tags-r-s/cfsprydataset.html",
-			"deprecated":"11"
+			"deprecated":"11",
+			"removed":"2025"
 		}
 	},
 	"links": []


### PR DESCRIPTION
Added 'deprecated' and 'removed' metadata for cfcol, cfformgroup, cfformitem, and cfsprydataset tags, indicating deprecation in ColdFusion 2016 and removal in 2025. Updated cfchart format parameter description to note 'flash' format removal in CF2025.