### PR TITLE
Clarify createPath and ignoreExists for Lucee/Boxlang

### DIFF
--- a/data/en/directorycreate.json
+++ b/data/en/directorycreate.json
@@ -7,8 +7,8 @@
 	"description":"Creates an on-disk or in-memory directory in the specified path",
 	"params": [
 		{"name":"path","description":"Absolute path of the directory to be created. Alternatively, you can specify an IP address, as in the following example: `DirectoryCreate(\"//12.3.123.123/c_drive/test\". \rNOTE: You have to have the required permissions to run this function.`);","required":true,"default":"","type":"string","values":[]},
-		{"name":"createPath","description":"Lucee Only. Create parent directory when it doesn't exist.","required":false,"default":"true","type":"boolean","values":[]},
-                {"name":"ignoreExists","description":"Lucee Only. Pass false (default) to throw an error if the directory already exists, or true to skip the create operation without an error.","required":false,"default":"false","type":"boolean","values":[]}
+		{"name":"createPath","description":"Lucee/Boxlang Only. Create parent directory when it doesn't exist.","required":false,"default":"true","type":"boolean","values":[]},
+                {"name":"ignoreExists","description":"Lucee/Boxlang Only. Pass false (default) to throw an error if the directory already exists, or true to skip the create operation without an error.","required":false,"default":"false","type":"boolean","values":[]}
 	],
 	"engines": {
 		"coldfusion": {"minimum_version":"9", "notes":"", "docs":"https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-c-d/DirectoryCreate.html"},


### PR DESCRIPTION
Updated descriptions for createPath and ignoreExists parameters to include compatibility with Boxlang.